### PR TITLE
Catch exceptions in hasattr checks

### DIFF
--- a/src/schemathesis/parametrizer.py
+++ b/src/schemathesis/parametrizer.py
@@ -92,4 +92,7 @@ class SchemaWrapper:
 
 def is_schemathesis_test(func: Callable) -> bool:
     """Check whether test is parametrized with schemathesis."""
-    return hasattr(func, "_schema_parametrizer")
+    try:
+        return hasattr(func, "_schema_parametrizer")
+    except Exception:
+        return False


### PR DESCRIPTION
When using the project with Flask, it raises `RuntimeError` on `hasattr` check. I think, `is_schemathesis_test` check should be stable against all exceptions in `__getattr__` of the test function because it means that `_schema_parametrizer` wasn't explicitly specified by Schemathesis. That's not the last problem with it but step towards to integration of the project with uninitialized Flask app.