### PR TITLE
[WIP] Add authorization to runner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,9 @@ The ``schemathesis`` command can be used to perform Schemathesis test cases:
 
     schemathesis run https://example.com/api/swagger.json
 
+If your application requires authorization then you can use ``--auth`` option for Basic Auth and ``--header`` to specify
+custom headers to be sent with each request.
+
 For the full list of options, run:
 
 .. code:: bash

--- a/src/schemathesis/commands.py
+++ b/src/schemathesis/commands.py
@@ -1,4 +1,5 @@
-from typing import Iterable
+from contextlib import contextmanager
+from typing import Dict, Generator, Iterable, Optional, Tuple
 from urllib.parse import urlparse
 
 import click
@@ -16,6 +17,33 @@ def main() -> None:
     """Command line tool for testing your web application built with Open API / Swagger specifications."""
 
 
+def validate_auth(
+    ctx: click.core.Context, param: click.core.Option, raw_value: Optional[str]
+) -> Optional[Tuple[str, str]]:
+    if raw_value is not None:
+        with reraise_format_error(raw_value):
+            user, password = tuple(raw_value.split(":"))
+        return user, password
+    return None
+
+
+def validate_headers(ctx: click.core.Context, param: click.core.Option, raw_value: Tuple[str, ...]) -> Dict[str, str]:
+    headers = {}
+    for header in raw_value:
+        with reraise_format_error(header):
+            key, value = header.split(":")
+        headers[key] = value.lstrip()
+    return headers
+
+
+@contextmanager
+def reraise_format_error(raw_value: str) -> Generator:
+    try:
+        yield
+    except ValueError:
+        raise click.BadParameter(f"Should be in KEY:VALUE format. Got: {raw_value}")
+
+
 @main.command(short_help="Perform schemathesis test.")
 @click.argument("schema", type=str)
 @click.option(
@@ -26,7 +54,25 @@ def main() -> None:
     type=click.Choice(DEFAULT_CHECKS_NAMES),
     default=DEFAULT_CHECKS_NAMES,
 )
-def run(schema: str, checks: Iterable[str] = DEFAULT_CHECKS_NAMES) -> None:
+@click.option(  # type: ignore
+    "--auth",
+    "-a",
+    help="Server user and password. Example: USER:PASSWORD",
+    type=str,
+    callback=validate_auth,  # type: ignore
+)
+@click.option(  # type: ignore
+    "--header",
+    "-H",
+    "headers",
+    help=r"Custom header in a that will be used in all requests to the server. Example: Authorization: Bearer\ 123",
+    multiple=True,
+    type=str,
+    callback=validate_headers,  # type: ignore
+)
+def run(
+    schema: str, auth: Optional[Tuple[str, str]], headers: Dict[str, str], checks: Iterable[str] = DEFAULT_CHECKS_NAMES
+) -> None:
     """Perform schemathesis test against an API specified by SCHEMA.
 
     SCHEMA must be a valid URL pointing to an Open API / Swagger specification.
@@ -38,6 +84,6 @@ def run(schema: str, checks: Iterable[str] = DEFAULT_CHECKS_NAMES) -> None:
 
     click.echo("Running schemathesis test cases ...")
 
-    runner.execute(schema, checks=selected_checks)
+    runner.execute(schema, checks=selected_checks, auth=auth, headers=headers)
 
     click.echo("Done.")

--- a/src/schemathesis/runner.py
+++ b/src/schemathesis/runner.py
@@ -1,12 +1,15 @@
 from contextlib import suppress
-from typing import Callable, Iterable
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
+from requests.auth import AuthBase
 
 from .loaders import from_uri
 from .models import Case
 from .schemas import BaseSchema
+
+Auth = Union[Tuple[str, str], AuthBase]
 
 
 def not_a_server_error(response: requests.Response) -> None:
@@ -17,17 +20,33 @@ def not_a_server_error(response: requests.Response) -> None:
 DEFAULT_CHECKS = (not_a_server_error,)
 
 
-def _execute_all_tests(schema: BaseSchema, base_url: str, checks: Iterable[Callable]) -> None:
+def _execute_all_tests(
+    schema: BaseSchema,
+    base_url: str,
+    checks: Iterable[Callable],
+    auth: Optional[Auth] = None,
+    headers: Optional[Dict[str, Any]] = None,
+) -> None:
     with requests.Session() as session, suppress(AssertionError):
+        if auth is not None:
+            session.auth = auth
+        if headers is not None:
+            session.headers.update(**headers)
         for _, test in schema.get_all_tests(single_test):
             test(session, base_url, checks)
 
 
-def execute(schema_uri: str, base_url: str = "", checks: Iterable[Callable] = DEFAULT_CHECKS) -> None:
+def execute(
+    schema_uri: str,
+    base_url: str = "",
+    checks: Iterable[Callable] = DEFAULT_CHECKS,
+    auth: Optional[Auth] = None,
+    headers: Optional[Dict[str, Any]] = None,
+) -> None:
     """Generate and run test cases against the given API definition."""
     schema = from_uri(schema_uri)
     base_url = base_url or get_base_url(schema_uri)
-    _execute_all_tests(schema, base_url, checks)
+    _execute_all_tests(schema, base_url, checks, auth, headers)
 
 
 def get_base_url(uri: str) -> str:


### PR DESCRIPTION
Closes #96 

TODO:

- [x] Changelog (won't do, since there is no release yet with CLI)
- [x] Documentation
- [x] Validation & cases when input is in the wrong format
- [x] Mutmut (probably we need to think about periodic runs or runs on a changed subset of the code )

I took `--auth` format from `httpie`, as the next steps we can add digest auth in the way similar to `httpie`
and `--header` format is from `curl`. also it could be similar to approach with prompting for a password but it is not that important now. What do you think?