### PR TITLE
CLI: Fix test generation if no filters are used

### DIFF
--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -4,6 +4,7 @@ import click
 
 from .. import runner
 from ..types import Filter
+from ..utils import dict_true_values
 from . import validators
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -68,11 +69,10 @@ def run(  # pylint: disable=too-many-arguments
 
     click.echo("Running schemathesis test cases ...")
 
-    runner.execute(
-        schema,
-        checks=selected_checks,
-        api_options=dict(auth=auth, headers=headers),
-        loader_options=dict(endpoint=endpoints, method=methods),
+    options = dict_true_values(
+        api_options=dict_true_values(auth=auth, headers=headers),
+        loader_options=dict_true_values(endpoint=endpoints, method=methods),
     )
+    runner.execute(schema, checks=selected_checks, **options)
 
     click.echo("Done.")

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import wraps
-from typing import Any, Callable, List, Set, Tuple, Union
+from typing import Any, Callable, List, Mapping, Set, Tuple, Union
 
 from .types import Filter
 
@@ -30,3 +30,8 @@ def force_tuple(item: Filter) -> Union[List, Set, Tuple]:
     if not isinstance(item, (list, set, tuple)):
         return (item,)
     return item
+
+
+def dict_true_values(**kwargs: Any) -> Mapping[str, Any]:
+    """Create dict with given kwargs while skipping items where bool(value) evaluates to False."""
+    return {key: value for key, value in kwargs.items() if bool(value)}

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -85,53 +85,26 @@ SCHEMA_URI = "https://example.com/swagger.json"
 @pytest.mark.parametrize(
     "args, expected",
     (
-        (
-            [SCHEMA_URI],
-            {
-                "checks": runner.DEFAULT_CHECKS,
-                "api_options": {"auth": None, "headers": {}},
-                "loader_options": {"endpoint": (), "method": ()},
-            },
-        ),
+        ([SCHEMA_URI], {"checks": runner.DEFAULT_CHECKS}),
         (
             [SCHEMA_URI, "--auth=test:test"],
-            {
-                "checks": runner.DEFAULT_CHECKS,
-                "api_options": {"auth": ("test", "test"), "headers": {}},
-                "loader_options": {"endpoint": (), "method": ()},
-            },
+            {"checks": runner.DEFAULT_CHECKS, "api_options": {"auth": ("test", "test")}},
         ),
         (
             [SCHEMA_URI, "--header=Authorization:Bearer 123"],
-            {
-                "checks": runner.DEFAULT_CHECKS,
-                "api_options": {"auth": None, "headers": {"Authorization": "Bearer 123"}},
-                "loader_options": {"endpoint": (), "method": ()},
-            },
+            {"checks": runner.DEFAULT_CHECKS, "api_options": {"headers": {"Authorization": "Bearer 123"}}},
         ),
         (
             [SCHEMA_URI, "--header=Authorization:  Bearer 123 "],
-            {
-                "checks": runner.DEFAULT_CHECKS,
-                "api_options": {"auth": None, "headers": {"Authorization": "Bearer 123 "}},
-                "loader_options": {"endpoint": (), "method": ()},
-            },
+            {"checks": runner.DEFAULT_CHECKS, "api_options": {"headers": {"Authorization": "Bearer 123 "}}},
         ),
         (
             [SCHEMA_URI, "--method=POST", "--method", "GET"],
-            {
-                "checks": runner.DEFAULT_CHECKS,
-                "api_options": {"auth": None, "headers": {}},
-                "loader_options": {"endpoint": (), "method": ("POST", "GET")},
-            },
+            {"checks": runner.DEFAULT_CHECKS, "loader_options": {"method": ("POST", "GET")}},
         ),
         (
             [SCHEMA_URI, "--endpoint=users"],
-            {
-                "checks": runner.DEFAULT_CHECKS,
-                "api_options": {"auth": None, "headers": {}},
-                "loader_options": {"endpoint": ("users",), "method": ()},
-            },
+            {"checks": runner.DEFAULT_CHECKS, "loader_options": {"endpoint": ("users",)}},
         ),
     ),
 )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,6 @@
-from schemathesis.utils import is_schemathesis_test
+import pytest
+
+from schemathesis.utils import dict_true_values, is_schemathesis_test
 
 
 def test_is_schemathesis_test(swagger_20):
@@ -10,3 +12,8 @@ def test_is_schemathesis_test(swagger_20):
 
     # Then is should be recognized as a schemathesis test
     assert is_schemathesis_test(test)
+
+
+@pytest.mark.parametrize("input_dict,expected_dict", [({}, {}), ({"a": 1, "b": 0}, {"a": 1}), ({"abc": None}, {})])
+def test_dict_true_values(input_dict, expected_dict):
+    assert dict_true_values(**input_dict) == expected_dict


### PR DESCRIPTION
It was broken if no endpoints/methods were used in CLI as the value for endpoints/methods was `()` which than was passed to `should_skip_method` and `should_skip_endpoint`.