### PR TITLE
cli: Add execution results with colors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,16 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Test executor collects results of execution. `29`_
+
+Changed
+~~~~~~~
+
+- CLI command `schemathesis run` prints results in a more readable way with a summary of passing checks.
+
 `0.8.1`_ - 2019-10-04
 ---------------------
 
@@ -203,6 +213,7 @@ Fixed
 .. _#35: https://github.com/kiwicom/schemathesis/issues/35
 .. _#34: https://github.com/kiwicom/schemathesis/issues/34
 .. _#30: https://github.com/kiwicom/schemathesis/issues/30
+.. _#29: https://github.com/kiwicom/schemathesis/issues/29
 .. _#28: https://github.com/kiwicom/schemathesis/issues/28
 .. _#24: https://github.com/kiwicom/schemathesis/issues/24
 .. _#21: https://github.com/kiwicom/schemathesis/issues/21

--- a/src/schemathesis/cli/output.py
+++ b/src/schemathesis/cli/output.py
@@ -1,0 +1,63 @@
+import shutil
+from contextlib import contextmanager
+from typing import Generator, Optional
+
+import click
+
+from .. import runner
+
+
+@contextmanager
+def print_in_section(
+    title: str = "", separator: str = "-", start_newline: bool = False, line_length: Optional[int] = None
+) -> Generator:
+    """Print section in terminal with the given title nicely centered.
+
+    Usage::
+
+        with print_in_section("statistics"):
+            print("Number of items:", len(items))
+    """
+    if start_newline:
+        click.echo()
+
+    line_length = line_length or shutil.get_terminal_size((100, 50)).columns
+
+    click.echo((f" {title} " if title else "").center(line_length, separator))
+    yield
+    click.echo(separator * line_length)
+
+
+def pretty_print_stats(stats: runner.StatsCollector, hypothesis_out: Optional[str] = None) -> None:
+    """Format and print stats collected by :obj:`runner.StatsCollector`."""
+    if hypothesis_out:
+        with print_in_section("FALSIFYING EXAMPLES", start_newline=True):
+            click.echo(click.style(hypothesis_out.strip(), fg="red"))
+
+    if stats.is_empty:
+        click.echo(click.style("No checks were performed.", bold=True))
+        return
+
+    padding = 20
+    col1_len = max(map(len, stats.data.keys())) + padding
+    col2_len = len(str(max(stats.data.values(), key=lambda v: v["total"])["total"])) * 2 + padding
+    col3_len = padding
+
+    template = f"{{:{col1_len}}}{{:{col2_len}}}{{:{col3_len}}}"
+
+    with print_in_section("SUMMARY", start_newline=True):
+        for check_name, results in stats.data.items():
+            if results["error"]:
+                verdict = "FAILED"
+                color = "red"
+            else:
+                verdict = "PASSED"
+                color = "green"
+
+            click.echo(
+                template.format(
+                    click.style(check_name, bold=True),
+                    f"{results['ok']} / {results['total']} passed",
+                    click.style(verdict, fg=color, bold=True),
+                )
+            )

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,6 +1,9 @@
+import io
+import sys
 import warnings
+from contextlib import contextmanager
 from functools import wraps
-from typing import Any, Callable, List, Mapping, Set, Tuple, Union
+from typing import Any, Callable, Generator, List, Mapping, Set, Tuple, Union
 
 from .types import Filter
 
@@ -35,3 +38,23 @@ def force_tuple(item: Filter) -> Union[List, Set, Tuple]:
 def dict_true_values(**kwargs: Any) -> Mapping[str, Any]:
     """Create dict with given kwargs while skipping items where bool(value) evaluates to False."""
     return {key: value for key, value in kwargs.items() if bool(value)}
+
+
+@contextmanager
+def stdout_listener() -> Generator:
+    """Replace stdout and listen for printed values (without printing them).
+
+    Usage::
+
+        with stdout_listener() as getvalue:
+            print("Hello, World")
+            captured_stdout = getvalue()  # captured_stdout == "Hello, World\n"
+    """
+    stdout = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = stdout
+
+    try:
+        yield stdout.getvalue
+    finally:
+        sys.stdout = old_stdout

--- a/test/cli/test_output.py
+++ b/test/cli/test_output.py
@@ -1,0 +1,50 @@
+import pytest
+
+from schemathesis import runner, utils
+from schemathesis.cli import output
+
+
+@pytest.mark.parametrize(
+    "title,separator,printed,expected",
+    [
+        ("TEST", "-", "data in section", "------- TEST -------\ndata in section\n--------------------\n"),
+        ("TEST", "*", "data in section", "******* TEST *******\ndata in section\n********************\n"),
+    ],
+)
+def test_print_in_section(title, separator, printed, expected):
+    with utils.stdout_listener() as getvalue:
+        with output.print_in_section(title, separator=separator, line_length=20):
+            print(printed)
+        printed = getvalue()
+
+    assert printed == expected
+
+
+def test_pretty_print_stats(mocker):
+    mocker.patch("schemathesis.cli.output.print_in_section")
+
+    with utils.stdout_listener() as getvalue:
+        output.pretty_print_stats(
+            runner.StatsCollector(
+                {
+                    "not_a_server_error": {"total": 5, "ok": 3, "error": 2},
+                    "different_check": {"total": 1, "ok": 1, "error": 0},
+                }
+            )
+        )
+        result = getvalue()
+
+    assert result == (
+        "not_a_server_error            3 / 5 passed          FAILED \n"
+        "different_check               1 / 1 passed          PASSED \n"
+    )
+
+
+def test_pretty_print_stats_empty(mocker):
+    mocker.patch("schemathesis.cli.output.print_in_section")
+
+    with utils.stdout_listener() as getvalue:
+        output.pretty_print_stats(runner.StatsCollector({}))
+        result = getvalue()
+
+    assert result == "No checks were performed.\n"

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -80,6 +80,13 @@ def test_execute(server, app):
     assert_request(app, 1, "GET", "/v1/users", headers)
 
 
+def test_execute_stats(server, app):
+    app["config"]["raise_exception"] = True
+    stats = execute(f"http://127.0.0.1:{server['port']}/swagger.yaml")
+    assert "not_a_server_error" in stats.data
+    assert dict(stats.data["not_a_server_error"]) == {"total": 3, "ok": 1, "error": 2}
+
+
 def test_auth(server, app):
     execute(f"http://127.0.0.1:{server['port']}/swagger.yaml", api_options=dict(auth=("test", "test")))
     assert len(app["saved_requests"]) == 2


### PR DESCRIPTION
- Fix https://github.com/kiwicom/schemathesis/issues/29

This is what the output looks like:

```
Running schemathesis test cases ...

------------------------------- FALSIFYING EXAMPLES ----------------------------
Falsifying example: single_test(case=Case(path='/ping', method='GET', path_parameters={}, headers={}, cookies={}, query={}, body={}, form_data={}), session=<requests.sessions.Session at 0x7fd21c90f090>, url='http://localhost:8080', checks=(
  <function schemathesis.runner.not_a_server_error>), stats=StatsCollector(data=defaultdict(<class 'collections.Counter'>, {'not_a_server_error': Counter({'total': 100, 'ok': 98, 'error': 2}))})))
--------------------------------------------------------------------------------

----------------------------------- SUMMARY ------------------------------------
not_a_server_error            98 / 100 passed          FAILED 
--------------------------------------------------------------------------------

Tests failed.
```

Maybe a bit overkill, but with hypothesis randomly printing stuff, I wanted to make it a bit more readable.