### PR TITLE
Capture Hypothesis output separately, without capturing the whole stdout during CLI run.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Changed
 - Base URL in schema instances could be reused when it is defined during creation.
   Now on, ``base_url`` argument in ``Case.call`` is optional in such cases. `#153`_
 - Hypothesis deadline is set to 500ms by default. `#138`_
+- Hypothesis output is captured separately, without capturing the whole stdout during CLI run.
 
 Fixed
 ~~~~~

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -129,11 +129,10 @@ def run(  # pylint: disable=too-many-arguments
         ),
     )
 
-    with utils.stdout_listener() as get_stdout:
+    with utils.capture_hypothesis_output() as hypothesis_output:
         stats = runner.execute(schema, checks=selected_checks, **options)
-        hypothesis_out = get_stdout()
 
-    output.pretty_print_stats(stats, hypothesis_out=hypothesis_out)
+    output.pretty_print_stats(stats, hypothesis_output=hypothesis_output)
     click.echo()
 
     if any(value.get("error") for value in stats.data.values()):

--- a/src/schemathesis/cli/output.py
+++ b/src/schemathesis/cli/output.py
@@ -1,6 +1,6 @@
 import shutil
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import Generator, List, Optional
 
 import click
 
@@ -28,11 +28,12 @@ def print_in_section(
     click.echo(separator * line_length)
 
 
-def pretty_print_stats(stats: runner.StatsCollector, hypothesis_out: Optional[str] = None) -> None:
+def pretty_print_stats(stats: runner.StatsCollector, hypothesis_output: Optional[List[str]] = None) -> None:
     """Format and print stats collected by :obj:`runner.StatsCollector`."""
-    if hypothesis_out:
+    if hypothesis_output:
         with print_in_section("FALSIFYING EXAMPLES", start_newline=True):
-            click.echo(click.style(hypothesis_out.strip(), fg="red"))
+            output = "\n".join(hypothesis_output)
+            click.echo(click.style(output, fg="red"))
 
     if stats.is_empty:
         click.echo(click.style("No checks were performed.", bold=True))

--- a/test/cli/test_output.py
+++ b/test/cli/test_output.py
@@ -1,4 +1,5 @@
 import pytest
+from hypothesis.reporting import report
 
 from schemathesis import runner, utils
 from schemathesis.cli import output
@@ -11,40 +12,38 @@ from schemathesis.cli import output
         ("TEST", "*", "data in section", "******* TEST *******\ndata in section\n********************\n"),
     ],
 )
-def test_print_in_section(title, separator, printed, expected):
-    with utils.stdout_listener() as getvalue:
-        with output.print_in_section(title, separator=separator, line_length=20):
-            print(printed)
-        printed = getvalue()
+def test_print_in_section(capsys, title, separator, printed, expected):
+    with output.print_in_section(title, separator=separator, line_length=20):
+        print(printed)
 
-    assert printed == expected
+    assert capsys.readouterr().out == expected
 
 
-def test_pretty_print_stats(mocker):
-    mocker.patch("schemathesis.cli.output.print_in_section")
-
-    with utils.stdout_listener() as getvalue:
-        output.pretty_print_stats(
-            runner.StatsCollector(
-                {
-                    "not_a_server_error": {"total": 5, "ok": 3, "error": 2},
-                    "different_check": {"total": 1, "ok": 1, "error": 0},
-                }
-            )
+def test_pretty_print_stats(capsys):
+    output.pretty_print_stats(
+        runner.StatsCollector(
+            {
+                "not_a_server_error": {"total": 5, "ok": 3, "error": 2},
+                "different_check": {"total": 1, "ok": 1, "error": 0},
+            }
         )
-        result = getvalue()
-
-    assert result == (
-        "not_a_server_error            3 / 5 passed          FAILED \n"
-        "different_check               1 / 1 passed          PASSED \n"
     )
 
+    lines = [line for line in capsys.readouterr().out.split("\n") if line]
+    assert lines[1:3] == [
+        "not_a_server_error            3 / 5 passed          FAILED ",
+        "different_check               1 / 1 passed          PASSED ",
+    ]
 
-def test_pretty_print_stats_empty(mocker):
-    mocker.patch("schemathesis.cli.output.print_in_section")
 
-    with utils.stdout_listener() as getvalue:
-        output.pretty_print_stats(runner.StatsCollector({}))
-        result = getvalue()
+def test_pretty_print_stats_empty(capsys):
+    output.pretty_print_stats(runner.StatsCollector({}))
+    assert capsys.readouterr().out == "No checks were performed.\n"
 
-    assert result == "No checks were performed.\n"
+
+def test_capture_hypothesis_output():
+    with utils.capture_hypothesis_output() as hypothesis_output:
+        value = "Some text"
+        report(value)
+        report(value)
+    assert hypothesis_output == [value, value]


### PR DESCRIPTION
It is needed to write our own text to stdout during the execution of the tests (#125 )