### PR TITLE
Fix test server generated wrong schema when ``endpoints`` option is passed via CLI.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,12 @@ Changelog
 Added
 ~~~~~
 
-- Display progress during the CLI run `#125`_
+- Display progress during the CLI run. `#125`_
+
+Fixed
+~~~~~
+
+- Test server generated wrong schema when ``endpoints`` option is passed via CLI. `#173`_
 
 `0.11.0`_ - 2019-10-22
 ----------------------
@@ -264,6 +269,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#173: https://github.com/kiwicom/schemathesis/issues/173
 .. _#167: https://github.com/kiwicom/schemathesis/issues/167
 .. _#153: https://github.com/kiwicom/schemathesis/issues/153
 .. _#149: https://github.com/kiwicom/schemathesis/issues/149

--- a/test/app.py
+++ b/test/app.py
@@ -120,7 +120,11 @@ def run_server(app: web.Application, port: int, timeout: float = 0.05) -> None:
 @click.argument("port", type=int)
 @click.option("--endpoints", type=CSVOption(Endpoint))
 def run_app(port, endpoints):
-    app = create_app(endpoints or ("success", "failure"))
+    if endpoints is not None:
+        endpoints = tuple(endpoint.name for endpoint in endpoints)
+    else:
+        endpoints = ("success", "failure")
+    app = create_app(endpoints)
     web.run_app(app, port=port)
 
 


### PR DESCRIPTION
Resolves #173 