### PR TITLE
Fix percentage output & make CLI output closer to pytest style

### DIFF
--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -115,8 +115,6 @@ def run(  # pylint: disable=too-many-arguments
     # pylint: disable=too-many-locals
     selected_checks = tuple(check for check in runner.DEFAULT_CHECKS if check.__name__ in checks)
 
-    click.echo("Running schemathesis test cases ...")
-
     if auth and auth_type == "digest":
         auth = HTTPDigestAuth(*auth)  # type: ignore
 

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -21,7 +21,8 @@ class ExecutionContext:
     """Storage for the current context of the execution."""
 
     hypothesis_output: List[str] = attr.ib()  # pragma: no mutate
-    current_position: int = attr.ib(default=0)  # pragma: no mutate
+    endpoints_processed: int = attr.ib(default=0)  # pragma: no mutate
+    current_line_length: int = attr.ib(default=0)  # pragma: no mutate
     terminal_size: os.terminal_size = attr.ib(factory=shutil.get_terminal_size)  # pragma: no mutate
 
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -209,22 +209,20 @@ def test_hypothesis_parameters(cli, schema_url):
 def test_cli_run_output_success(cli, schema_url):
     result = cli.run_inprocess(schema_url)
     assert result.exit_code == 0
-    assert " FALSIFYING EXAMPLES " not in result.stdout
+    assert " HYPOTHESIS OUTPUT " not in result.stdout
     assert " SUMMARY " in result.stdout
 
     lines = result.stdout.split("\n")
-    assert "Running schemathesis test cases ..." in lines
     assert "Tests succeeded." in lines
 
 
 def test_cli_run_output_with_errors(cli, schema_url):
     result = cli.run_inprocess(schema_url)
     assert result.exit_code == 1
-    assert " FALSIFYING EXAMPLES " in result.stdout
+    assert " HYPOTHESIS OUTPUT " in result.stdout
     assert " SUMMARY " in result.stdout
 
     lines = result.stdout.split("\n")
-    assert "Running schemathesis test cases ..." in lines
     assert "not_a_server_error            1 / 3 passed          FAILED " in lines
     assert "Tests failed." in lines
 
@@ -233,7 +231,7 @@ def test_cli_run_output_with_errors(cli, schema_url):
 def test_cli_run_output_empty(cli, schema_url):
     result = cli.run_inprocess(schema_url)
     assert result.exit_code == 0
-    assert " FALSIFYING EXAMPLES " not in result.stdout
+    assert " HYPOTHESIS OUTPUT " not in result.stdout
     assert " SUMMARY " not in result.stdout
 
     lines = result.stdout.split("\n")

--- a/test/cli/test_output.py
+++ b/test/cli/test_output.py
@@ -18,15 +18,15 @@ def click_context():
 @pytest.mark.parametrize(
     "title,separator,printed,expected",
     [
-        ("TEST", "-", "data in section", "------- TEST -------\ndata in section\n--------------------\n"),
-        ("TEST", "*", "data in section", "******* TEST *******\ndata in section\n********************\n"),
+        ("TEST", "-", "data in section", "------- TEST -------"),
+        ("TEST", "*", "data in section", "******* TEST *******"),
     ],
 )
-def test_print_in_section(capsys, title, separator, printed, expected):
-    with output.print_in_section(title, separator=separator, line_length=20):
-        print(printed)
-
-    assert capsys.readouterr().out == expected
+def test_display_section_name(capsys, title, separator, printed, expected):
+    output.display_section_name(title, separator=separator)
+    out = capsys.readouterr().out.strip()
+    assert len(out) == output.get_terminal_width()
+    assert expected in out
 
 
 def test_display_statistic(capsys):
@@ -68,11 +68,11 @@ def test_get_percentage(position, length, expected):
     assert output.get_percentage(position, length) == expected
 
 
-@pytest.mark.parametrize("current_position, percentage", ((0, "[  0%]"), (1, "[100%]")))
-def test_display_percentage(capsys, swagger_20, current_position, percentage):
+@pytest.mark.parametrize("endpoints_processed, percentage", ((0, "[  0%]"), (1, "[100%]")))
+def test_display_percentage(capsys, swagger_20, endpoints_processed, percentage):
     statistic = StatsCollector()
     context = runner.events.ExecutionContext([])
-    context.current_position = current_position
+    context.endpoints_processed = endpoints_processed
     endpoint = Endpoint("/success", "GET")
     event = runner.events.AfterExecution(
         statistic=statistic, schema=swagger_20, endpoint=endpoint, result=runner.events.ExecutionResult.success
@@ -82,7 +82,7 @@ def test_display_percentage(capsys, swagger_20, current_position, percentage):
     assert out == click.style(percentage, fg="cyan")
 
 
-def test_display_falsifying_examples(capsys):
-    output.display_falsifying_examples(["foo", "bar"])
+def test_display_hypothesis_output(capsys):
+    output.display_hypothesis_output(["foo", "bar"])
     lines = capsys.readouterr().out.split("\n")
-    assert " ".join(lines[2:4]) == click.style("foo bar", fg="red")
+    assert " ".join(lines[1:3]) == click.style("foo bar", fg="red")


### PR DESCRIPTION
TODO:

- [ ] Display exceptions from Hypothesis. Now, e.g. deadline missing is not shown, but only falsifying example for this case. Maybe there should be two sections - "hypothesis report" and "hypothesis errors"