### PR TITLE
Restructure CLI statistic

### DIFF
--- a/src/schemathesis/cli/output.py
+++ b/src/schemathesis/cli/output.py
@@ -89,10 +89,10 @@ def handle_finished(context: events.ExecutionContext, event: events.Finished) ->
     """Show the outcome of the whole testing session."""
     click.echo()
     display_hypothesis_output(context.hypothesis_output)
-    display_statistic(event.statistic)
+    display_statistic(event.results)
     click.echo()
 
-    if event.statistic.has_errors:
+    if event.results.has_errors:
         click.secho("Tests failed.", fg="red")
         raise click.exceptions.Exit(1)
 
@@ -107,7 +107,7 @@ def display_hypothesis_output(hypothesis_output: List[str]) -> None:
         click.secho(output, fg="red")
 
 
-def display_statistic(statistic: runner.StatsCollector) -> None:
+def display_statistic(statistic: runner.ExecutionResultSet) -> None:
     """Format and print statistic collected by :obj:`runner.StatsCollector`."""
     display_section_name("SUMMARY")
     click.echo()
@@ -116,13 +116,14 @@ def display_statistic(statistic: runner.StatsCollector) -> None:
         return
 
     padding = 20
-    col1_len = max(map(len, statistic.data.keys())) + padding
-    col2_len = len(str(max(statistic.data.values(), key=lambda v: v["total"])["total"])) * 2 + padding
+    # TODO. what if no checks were done during the test??
+    col1_len = max(map(len, statistic.keys())) + padding
+    col2_len = len(str(max(statistic.values(), key=lambda v: v["total"])["total"])) * 2 + padding
     col3_len = padding
 
     template = f"{{:{col1_len}}}{{:{col2_len}}}{{:{col3_len}}}"
 
-    for check_name, results in statistic.data.items():
+    for check_name, results in statistic.total.items():
         display_check_result(check_name, results, template)
 
 

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -1,19 +1,12 @@
 import os
 import shutil
-from enum import IntEnum
 from typing import Callable, Iterable, List
 
 import attr
 import hypothesis
 
-from ..models import Endpoint, ExecutionResultSet
+from ..models import Endpoint, Status, TestResultSet
 from ..schemas import BaseSchema
-
-
-class ExecutionResult(IntEnum):
-    success = 1
-    failure = 2
-    error = 3
 
 
 @attr.s(slots=True)
@@ -28,7 +21,7 @@ class ExecutionContext:
 
 @attr.s()  # pragma: no mutate
 class ExecutionEvent:
-    results: ExecutionResultSet = attr.ib()  # pragma: no mutate
+    results: TestResultSet = attr.ib()  # pragma: no mutate
     schema: BaseSchema = attr.ib()  # pragma: no mutate
 
 
@@ -48,7 +41,7 @@ class BeforeExecution(ExecutionEvent):
 @attr.s(slots=True)
 class AfterExecution(ExecutionEvent):
     endpoint: Endpoint = attr.ib()  # pragma: no mutate
-    result: ExecutionResult = attr.ib()  # pragma: no mutate
+    status: Status = attr.ib()  # pragma: no mutate
 
 
 @attr.s(slots=True)  # pragma: no mutate

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -6,7 +6,7 @@ from typing import Callable, Iterable, List
 import attr
 import hypothesis
 
-from ..models import Endpoint, StatsCollector
+from ..models import Endpoint, ExecutionResultSet
 from ..schemas import BaseSchema
 
 
@@ -28,7 +28,7 @@ class ExecutionContext:
 
 @attr.s()  # pragma: no mutate
 class ExecutionEvent:
-    statistic: StatsCollector = attr.ib()  # pragma: no mutate
+    results: ExecutionResultSet = attr.ib()  # pragma: no mutate
     schema: BaseSchema = attr.ib()  # pragma: no mutate
 
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -223,6 +223,7 @@ def test_cli_run_output_with_errors(cli, schema_url):
     assert " SUMMARY " in result.stdout
 
     lines = result.stdout.split("\n")
+    print(lines)
     assert "not_a_server_error            1 / 3 passed          FAILED " in lines
     assert "Tests failed." in lines
 

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -53,8 +53,7 @@ def test_execute(schema_url, app):
     assert_request(app, 2, "GET", "/api/success", headers)
 
     # And statistic is showing the breakdown of cases types
-    assert "not_a_server_error" in stats.data
-    assert dict(stats.data["not_a_server_error"]) == {"total": 3, "ok": 1, "error": 2}
+    assert stats.total["not_a_server_error"] == {"total": 3, "ok": 1, "error": 2}
 
 
 def test_auth(schema_url, app):


### PR DESCRIPTION
Overview of the changes:
- results for checks in the single Hypothesis test are collected as a list of results, rather than aggregation
- removed `suppress(AssertionError` since we have `try/except` with additional logic
- results for different tests are collected as separate results
- Renaming to reflect the changes in the structure

This restructure unblocks development of:
- Showing formatted falsifying examples grouped by method/endpoint in the "HYPOTHESIS OUTPUT" section
- Showing detailed statistic per method/endpoint in the "SUMMARY" section

For these features, we need a structured, non-aggregated output from the runner, which this PR implements