### PR TITLE
Fix handling for errors other than `AssertionError` and `HypothesisException` in the runner

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,15 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Handling for errors other than ``AssertionError`` and ``HypothesisException`` in the runner. `#189`_
+
 Changed
 ~~~~~~~
 
-- Display "SUMMARY" section in the CLI output for empty test suites
+- Display "SUMMARY" section in the CLI output for empty test suites.
 
 `0.12.0`_ - 2019-10-28
 ----------------------
@@ -284,6 +289,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#189: https://github.com/kiwicom/schemathesis/issues/189
 .. _#173: https://github.com/kiwicom/schemathesis/issues/173
 .. _#172: https://github.com/kiwicom/schemathesis/issues/172
 .. _#167: https://github.com/kiwicom/schemathesis/issues/167

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -73,7 +73,7 @@ def execute_from_schema(
                 status = Status.success
             except AssertionError:
                 status = Status.failure
-            except hypothesis.errors.HypothesisException:
+            except Exception:
                 status = Status.error
             results.append(result)
             yield events.AfterExecution(results=results, schema=schema, endpoint=endpoint, status=status)

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -104,9 +104,12 @@ def test_hypothesis_deadline(schema_url, app):
     execute(schema_url, hypothesis_options={"deadline": 500})
 
 
+@pytest.mark.parametrize(
+    "options", ({"api_options": {"base_url": "http://127.0.0.1:1/"}}, {"hypothesis_options": {"deadline": 1}})
+)
 @pytest.mark.endpoints("slow")
-def test_hypothesis_error(schema_url, app):
-    results = prepare(schema_url, hypothesis_options={"deadline": 1})
+def test_exceptions(schema_url, app, options):
+    results = prepare(schema_url, **options)
     assert any([event.status == Status.error for event in results if isinstance(event, events.AfterExecution)])
 
 


### PR DESCRIPTION
Resolves #189 