### PR TITLE
Fix wrong handling of `base_url` parameter in runner if it has a trailing slash

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Wrong handling of ``base_url`` parameter in runner if it has a trailing slash. `#194`_
+
 `0.12.1`_ - 2019-10-28
 ----------------------
 
@@ -294,6 +299,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#194: https://github.com/kiwicom/schemathesis/issues/194
 .. _#191: https://github.com/kiwicom/schemathesis/issues/191
 .. _#189: https://github.com/kiwicom/schemathesis/issues/189
 .. _#173: https://github.com/kiwicom/schemathesis/issues/173

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, Iterable, Optional, Tuple, Union
+from urllib.parse import urljoin
 
 import hypothesis
 import hypothesis.errors
@@ -143,6 +144,7 @@ def single_test(
 
 def get_response(session: requests.Session, base_url: str, case: Case) -> requests.Response:
     """Send an appropriate request to the target."""
-    return session.request(
-        case.method, f"{base_url}{case.formatted_path}", headers=case.headers, params=case.query, json=case.body
-    )
+    if not base_url.endswith("/"):
+        base_url += "/"
+    url = urljoin(base_url, case.formatted_path.lstrip("/"))
+    return session.request(case.method, url, headers=case.headers, params=case.query, json=case.body)

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -26,7 +26,7 @@ def assert_not_request(app: web.Application, method: str, path: str) -> None:
 
 def test_execute_base_url_not_found(base_url, schema_url, app):
     # When base URL is pointing to an unknown location
-    execute(schema_url, api_options={"base_url": f"{base_url}/404"})
+    execute(schema_url, api_options={"base_url": f"{base_url}/404/"})
     # Then the runner should use this base
     # And they will not reach the application
     assert len(app["incoming_requests"]) == 0
@@ -67,6 +67,19 @@ def test_auth(schema_url, app):
     assert_request(app, 0, "GET", "/api/failure", headers)
     assert_request(app, 1, "GET", "/api/failure", headers)
     assert_request(app, 2, "GET", "/api/success", headers)
+
+
+@pytest.mark.parametrize("converter", (lambda x: x, lambda x: x + "/"))
+def test_base_url(base_url, schema_url, app, converter):
+    base_url = converter(base_url)
+    # When `base_url` is specified explicitly with or without trailing slash
+    execute(schema_url, api_options={"base_url": base_url})
+
+    # Then each request should reach the app in both cases
+    assert len(app["incoming_requests"]) == 3
+    assert_request(app, 0, "GET", "/api/failure")
+    assert_request(app, 1, "GET", "/api/failure")
+    assert_request(app, 2, "GET", "/api/success")
 
 
 def test_execute_with_headers(schema_url, app):


### PR DESCRIPTION
Resolves #194 