### PR TITLE
Speedup tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,7 +71,7 @@ def cli(testdir):
     return Runner()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def simple_schema():
     return {
         "swagger": "2.0",
@@ -92,7 +92,7 @@ def simple_schema():
     }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def swagger_20(simple_schema):
     return schemathesis.from_dict(simple_schema)
 

--- a/test/test_direct_access.py
+++ b/test/test_direct_access.py
@@ -1,6 +1,7 @@
 import hypothesis.strategies as st
 import pytest
 
+import schemathesis
 from schemathesis.models import Case, Endpoint
 from schemathesis.schemas import endpoints_to_dict
 
@@ -9,14 +10,15 @@ def test_contains(swagger_20):
     assert "/v1/users" in swagger_20
 
 
-def test_getitem(swagger_20, mocker):
+def test_getitem(simple_schema, mocker):
+    swagger = schemathesis.from_dict(simple_schema)
     mocked = mocker.patch("schemathesis.schemas.endpoints_to_dict", wraps=endpoints_to_dict)
-    assert "_endpoints" not in swagger_20.__dict__
-    assert isinstance(swagger_20["/v1/users"], dict)
+    assert "_endpoints" not in swagger.__dict__
+    assert isinstance(swagger["/v1/users"], dict)
     assert mocked.call_count == 1
     # Check cached access
-    assert "_endpoints" in swagger_20.__dict__
-    assert isinstance(swagger_20["/v1/users"], dict)
+    assert "_endpoints" in swagger.__dict__
+    assert isinstance(swagger["/v1/users"], dict)
     assert mocked.call_count == 1
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from functools import lru_cache
 from typing import Any, Callable, Dict, Type
 
 import yaml
@@ -23,12 +24,17 @@ def get_schema(schema_name: str = "simple_swagger.yaml", **kwargs: Any) -> BaseS
 
 
 def make_schema(schema_name: str = "simple_swagger.yaml", **kwargs: Any) -> Dict[str, Any]:
-    path = get_schema_path(schema_name)
-    with open(path) as fd:
-        schema = yaml.safe_load(fd)
+    schema = load_schema(schema_name)
     if kwargs is not None:
         schema = merge(kwargs, schema)
     return schema
+
+
+@lru_cache()
+def load_schema(schema_name: str) -> Dict[str, Any]:
+    path = get_schema_path(schema_name)
+    with open(path) as fd:
+        return yaml.safe_load(fd)
 
 
 def merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
Benchmarked with `hyperfine`. Not patched:

```
⇒  hyperfine pytest
Benchmark #1: pytest
  Time (mean ± σ):     26.637 s ±  0.321 s    [User: 22.430 s, System: 0.938 s]
  Range (min … max):   26.213 s … 27.140 s    10 runs
```

vs patched:

```
⇒  hyperfine pytest   
Benchmark #1: pytest
  Time (mean ± σ):     24.258 s ±  0.273 s    [User: 20.051 s, System: 0.958 s]
  Range (min … max):   23.969 s … 24.913 s    10 run
```

which is ~9% improvement