### PR TITLE
Sort items in `parametrize` args

### DIFF
--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -23,7 +23,7 @@ def make_case(**kwargs: Any) -> Case:
     return _make(Case, **kwargs)
 
 
-@pytest.mark.parametrize("name", PARAMETERS)
+@pytest.mark.parametrize("name", sorted(PARAMETERS))
 def test_get_examples(name):
     example = {"name": "John"}
     endpoint = make_endpoint(


### PR DESCRIPTION
It will make the collected node names list the same on each collection
and thus will make `pytest-xdist` work. Reproducible test collection is
required for it