### PR TITLE
Add summary line in the CLI output with the number of passed / failed/ errored endpoint tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Added
 
 - An option to configure request timeout for CLI / Runner. `#204`_
 - A help snippet to reproduce errors caught by Schemathesis. `#206`_
+- Summary line in the CLI output with the number of passed / failed / errored endpoint tests. `#209`_
 
 Fixed
 ~~~~~
@@ -330,6 +331,7 @@ Fixed
 .. _#215: https://github.com/kiwicom/schemathesis/issues/215
 .. _#214: https://github.com/kiwicom/schemathesis/issues/214
 .. _#212: https://github.com/kiwicom/schemathesis/issues/212
+.. _#209: https://github.com/kiwicom/schemathesis/issues/209
 .. _#206: https://github.com/kiwicom/schemathesis/issues/206
 .. _#204: https://github.com/kiwicom/schemathesis/issues/204
 .. _#203: https://github.com/kiwicom/schemathesis/issues/203

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-instance-attributes
 from collections import Counter
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import attr
@@ -179,12 +179,27 @@ class TestResultSet:
     @property
     def has_failures(self) -> bool:
         """If any result has any failures."""
-        return any(result.has_failures for result in self.results)
+        return any(result.has_failures for result in self)
 
     @property
     def has_errors(self) -> bool:
         """If any result has any errors."""
-        return any(result.has_errors for result in self.results)
+        return any(result.has_errors for result in self)
+
+    def _count(self, predicate: Callable) -> int:
+        return sum(1 for result in self if predicate(result))
+
+    @property
+    def passed_count(self) -> int:
+        return self._count(lambda result: not result.has_errors and not result.has_failures)
+
+    @property
+    def failed_count(self) -> int:
+        return self._count(lambda result: result.has_failures and not result.is_errored)
+
+    @property
+    def errored_count(self) -> int:
+        return self._count(lambda result: result.has_errors or result.is_errored)
 
     @property
     def total(self) -> Dict[str, Dict[Union[str, Status], int]]:

--- a/test/app/__init__.py
+++ b/test/app/__init__.py
@@ -148,7 +148,7 @@ def run_app(port: int, endpoints: List[Endpoint]) -> None:
     if endpoints is not None:
         prepared_endpoints = tuple(endpoint.name for endpoint in endpoints)
     else:
-        prepared_endpoints = ("success", "failure")
+        prepared_endpoints = ()
     app = create_app(prepared_endpoints)
     web.run_app(app, port=port)
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -215,8 +215,8 @@ def test_cli_run_output_success(cli, schema_url):
     assert " HYPOTHESIS OUTPUT " not in result.stdout
     assert " SUMMARY " in result.stdout
 
-    lines = result.stdout.split("\n")
-    assert "Tests succeeded." in lines
+    lines = result.stdout.strip().split("\n")
+    assert "== 1 passed ==" in lines[-1]
 
 
 def test_cli_run_output_with_errors(cli, schema_url):
@@ -225,9 +225,9 @@ def test_cli_run_output_with_errors(cli, schema_url):
     assert " HYPOTHESIS OUTPUT " not in result.stdout
     assert " SUMMARY " in result.stdout
 
-    lines = result.stdout.split("\n")
+    lines = result.stdout.strip().split("\n")
     assert "not_a_server_error            1 / 3 passed          FAILED " in lines
-    assert "Tests failed." in lines
+    assert "== 1 passed, 1 failed ==" in lines[-1]
 
 
 @pytest.mark.endpoints()
@@ -237,9 +237,9 @@ def test_cli_run_output_empty(cli, schema_url):
     assert " HYPOTHESIS OUTPUT " not in result.stdout
     assert " SUMMARY " in result.stdout
 
-    lines = result.stdout.split("\n")
+    lines = result.stdout.strip().split("\n")
     assert "No checks were performed." in lines
-    assert "Tests succeeded." in lines
+    assert "= Empty test suite =" in lines[-1]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #209 