### PR TITLE
Check to verify response status & content type in CLI / Runner

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,8 @@ Changelog
 Added
 ~~~~~
 
-- CLI: Support file paths in `schema` argument `#119`_
+- CLI: Support file paths in ``schema`` argument. `#119`_
+- Check to verify response status & content type in CLI / Runner. `#101`_
 
 `0.13.2`_ - 2019-11-05
 ----------------------
@@ -402,6 +403,7 @@ Fixed
 .. _#109: https://github.com/kiwicom/schemathesis/issues/109
 .. _#107: https://github.com/kiwicom/schemathesis/issues/107
 .. _#106: https://github.com/kiwicom/schemathesis/issues/106
+.. _#101: https://github.com/kiwicom/schemathesis/issues/101
 .. _#99: https://github.com/kiwicom/schemathesis/issues/99
 .. _#98: https://github.com/kiwicom/schemathesis/issues/98
 .. _#94: https://github.com/kiwicom/schemathesis/issues/94

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -18,6 +18,7 @@ from .options import CSVOption
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 DEFAULT_CHECKS_NAMES = tuple(check.__name__ for check in runner.DEFAULT_CHECKS)
+ALL_CHECKS_NAMES = tuple(check.__name__ for check in runner.ALL_CHECKS)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -33,7 +34,7 @@ def main() -> None:
     "-c",
     multiple=True,
     help="List of checks to run.",
-    type=click.Choice(DEFAULT_CHECKS_NAMES),
+    type=click.Choice(ALL_CHECKS_NAMES),
     default=DEFAULT_CHECKS_NAMES,
 )
 @click.option(
@@ -119,7 +120,7 @@ def run(  # pylint: disable=too-many-arguments
     SCHEMA must be a valid URL or file path pointing to an Open API / Swagger specification.
     """
     # pylint: disable=too-many-locals
-    selected_checks = tuple(check for check in runner.DEFAULT_CHECKS if check.__name__ in checks)
+    selected_checks = tuple(check for check in runner.ALL_CHECKS if check.__name__ in checks)
 
     if auth and auth_type == "digest":
         auth = HTTPDigestAuth(*auth)  # type: ignore

--- a/src/schemathesis/cli/output.py
+++ b/src/schemathesis/cli/output.py
@@ -26,7 +26,7 @@ def display_section_name(title: str, separator: str = "=", **kwargs: Any) -> Non
 
 
 def display_subsection(result: TestResult) -> None:
-    section_name = f"{result.method}: {result.path}"
+    section_name = f"{result.endpoint.method}: {result.endpoint.path}"
     display_section_name(section_name, "_", fg="red")
 
 

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -10,6 +10,7 @@ from hypothesis.searchstrategy import SearchStrategy
 from .types import Body, Cookies, FormData, Headers, PathParameters, Query
 
 if TYPE_CHECKING:
+    from .schemas import BaseSchema
     import requests  # Typechecking-only import to speedup import of schemathesis
 
 
@@ -107,6 +108,7 @@ class Endpoint:
 
     path: str = attr.ib()  # pragma: no mutate
     method: str = attr.ib()  # pragma: no mutate
+    definition: Dict[str, Any] = attr.ib()  # pragma: no mutate
     base_url: Optional[str] = attr.ib(default=None)  # pragma: no mutate
     path_parameters: PathParameters = attr.ib(factory=empty_object)  # pragma: no mutate
     headers: Headers = attr.ib(factory=empty_object)  # pragma: no mutate
@@ -142,8 +144,8 @@ class Check:
 class TestResult:
     """Result of a single test."""
 
-    path: str = attr.ib()  # pragma: no mutate
-    method: str = attr.ib()  # pragma: no mutate
+    endpoint: Endpoint = attr.ib()  # pragma: no mutate
+    schema: "BaseSchema" = attr.ib()  # pragma: no mutate
     checks: List[Check] = attr.ib(factory=list)  # pragma: no mutate
     errors: List[Tuple[Exception, Optional[Case]]] = attr.ib(factory=list)  # pragma: no mutate
     is_errored: bool = attr.ib(default=False)  # pragma: no mutate

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -155,7 +155,7 @@ class SwaggerV20(BaseSchema):
         base_url = self.base_url
         if base_url is not None:
             base_url = base_url.rstrip("/")  # pragma: no mutate
-        endpoint = Endpoint(path=full_path, method=method.upper(), base_url=base_url)
+        endpoint = Endpoint(path=full_path, method=method.upper(), definition=definition, base_url=base_url)
         for parameter in parameters:
             self.process_parameter(endpoint, parameter)
         return endpoint

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,3 +1,4 @@
+import cgi
 import traceback
 import warnings
 from contextlib import contextmanager
@@ -91,3 +92,15 @@ def capture_hypothesis_output() -> Generator[List[str], None, None]:
 
 def format_exception(error: Exception) -> str:
     return "".join(traceback.format_exception_only(type(error), error))
+
+
+def parse_content_type(content_type: str) -> Tuple[str, str]:
+    """Parse Content Type and return main type and subtype."""
+    content_type, _ = cgi.parse_header(content_type)
+    main_type, sub_type = content_type.split("/", 1)
+    return main_type.lower(), sub_type.lower()
+
+
+def are_content_types_equal(source: str, target: str) -> bool:
+    """Check if two content types are the same excluding options."""
+    return parse_content_type(source) == parse_content_type(target)

--- a/test/app/__init__.py
+++ b/test/app/__init__.py
@@ -27,6 +27,8 @@ class Endpoint(Enum):
     invalid = ("POST", "/api/invalid", handlers.unsatisfiable)
     flaky = ("GET", "/api/flaky", handlers.flaky)
     multipart = ("POST", "/api/multipart", handlers.multipart)
+    teapot = ("POST", "/api/teapot", handlers.teapot)
+    text = ("GET", "/api/text", handlers.text)
 
 
 def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> web.Application:
@@ -84,6 +86,7 @@ def make_schema(endpoints: Tuple[str, ...]) -> Dict:
         "host": "127.0.0.1:8888",
         "basePath": "/api",
         "schemes": ["http"],
+        "produces": ["application/json"],
         "paths": {},
     }
     for endpoint in endpoints:
@@ -111,8 +114,10 @@ def make_schema(endpoints: Tuple[str, ...]) -> Dict:
                     {"in": "formData", "name": "value", "required": True, "type": "integer"},
                 ]
             }
-        else:
+        elif endpoint == "teapot":
             schema = {"produces": ["application/json"], "responses": {200: {"description": "OK"}}}
+        else:
+            schema = {"responses": {200: {"description": "OK"}, "default": {"description": "Default response"}}}
         template["paths"][f"/{endpoint}"] = {method: schema}
     return template
 

--- a/test/app/handlers.py
+++ b/test/app/handlers.py
@@ -7,6 +7,14 @@ async def success(request: web.Request) -> web.Response:
     return web.json_response({"success": True})
 
 
+async def teapot(request: web.Request) -> web.Response:
+    return web.json_response({"success": True}, status=418)
+
+
+async def text(request: web.Request) -> web.Response:
+    return web.Response(body="Text response", content_type="text/plain")
+
+
 async def failure(request: web.Request) -> web.Response:
     raise web.HTTPInternalServerError
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -85,7 +85,7 @@ def test_commands_run_help(cli):
         "  specification.",
         "",
         "Options:",
-        "  -c, --checks [not_a_server_error]",
+        "  -c, --checks [not_a_server_error|status_code_conformance|content_type_conformance]",
         "                                  List of checks to run.",
         "  -a, --auth TEXT                 Server user and password. Example:",
         "                                  USER:PASSWORD",
@@ -373,6 +373,18 @@ def test_invalid_endpoint(cli, schema_url):
     # And more clear error message is displayed instead of Hypothesis one
     lines = result.stdout.split("\n")
     assert "schemathesis.exceptions.InvalidSchema: Invalid schema for this endpoint" in lines
+
+
+@pytest.mark.endpoints("teapot")
+def test_status_code_conformance(cli, schema_url):
+    # When endpoint returns a status code, that is not listed in "responses"
+    # And "status_code_conformance" is specified
+    result = cli.run_inprocess(schema_url, "-c", "status_code_conformance")
+    # Then the whole Schemathesis run should fail
+    assert result.exit_code == 1
+    # And this endpoint should be marked as failed in the progress line
+    assert "POST /api/teapot F" in result.stdout
+    assert "status_code_conformance            0 / 2 passed          FAILED" in result.stdout
 
 
 def test_connection_error(cli, schema_url):

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -1,0 +1,41 @@
+import pytest
+import requests
+
+from schemathesis import models
+from schemathesis.runner import content_type_conformance
+
+
+@pytest.fixture()
+def response(request):
+    response = requests.Response()
+    response.headers["Content-Type"] = request.param
+    return response
+
+
+@pytest.fixture()
+def results(request, swagger_20) -> models.TestResult:
+    endpoint = models.Endpoint("/path", "GET", definition={"produces": request.param})
+    return models.TestResult(endpoint, swagger_20)
+
+
+@pytest.mark.parametrize(
+    "response, results",
+    (
+        ("application/json", []),
+        ("application/json", ["application/json"]),
+        ("application/json;charset=utf-8", ["application/json"]),
+    ),
+    indirect=["response", "results"],
+)
+def test_content_type_conformance_valid(response, results):
+    assert content_type_conformance(response, results) is None
+
+
+@pytest.mark.parametrize(
+    "response, results",
+    (("plain/text", ["application/json"]), ("plain/text;charset=utf-8", ["application/json"])),
+    indirect=["response", "results"],
+)
+def test_content_type_conformance_invalid(response, results):
+    with pytest.raises(AssertionError):
+        content_type_conformance(response, results)

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -15,7 +15,7 @@ def _make(cls: Type[T], **kwargs: Any) -> T:
 
 
 def make_endpoint(**kwargs: Any) -> Endpoint:
-    return _make(Endpoint, **kwargs)
+    return _make(Endpoint, definition={}, **kwargs)
 
 
 def make_case(**kwargs: Any) -> Case:
@@ -44,6 +44,7 @@ def test_no_body_in_get():
     endpoint = Endpoint(
         path="/api/success",
         method="GET",
+        definition={},
         query={
             "required": ["name"],
             "type": "object",
@@ -120,6 +121,7 @@ def test_valid_headers(base_url):
     endpoint = Endpoint(
         "/api/success",
         "GET",
+        definition={},
         base_url=base_url,
         headers={
             "properties": {"api_key": {"name": "api_key", "in": "header", "type": "string"}},

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from schemathesis.utils import dict_true_values, is_schemathesis_test
+from schemathesis.utils import are_content_types_equal, dict_true_values, is_schemathesis_test, parse_content_type
 
 
 def test_is_schemathesis_test(swagger_20):
@@ -17,3 +17,31 @@ def test_is_schemathesis_test(swagger_20):
 @pytest.mark.parametrize("input_dict,expected_dict", [({}, {}), ({"a": 1, "b": 0}, {"a": 1}), ({"abc": None}, {})])
 def test_dict_true_values(input_dict, expected_dict):
     assert dict_true_values(**input_dict) == expected_dict
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ("text/plain", ("text", "plain")),
+        ("application/json+problem", ("application", "json+problem")),
+        ("application/json;charset=utf-8", ("application", "json")),
+        ("application/json/random", ("application", "json/random")),
+    ),
+)
+def test_parse_content_type(value, expected):
+    assert parse_content_type(value) == expected
+
+
+@pytest.mark.parametrize(
+    "first, second, expected",
+    (
+        ("application/json", "application/json", True),
+        ("APPLICATION/JSON", "application/json", True),
+        ("application/json", "application/json;charset=utf-8", True),
+        ("application/json;charset=utf-8", "application/json;charset=utf-8", True),
+        ("application/json;charset=utf-8", "application/json", True),
+        ("text/plain", "application/json", False),
+    ),
+)
+def test_are_content_types_equal(first, second, expected):
+    assert are_content_types_equal(first, second) is expected


### PR DESCRIPTION
Resolves #101 
TODO:
- [x] check produced content type on the global level. It could be defined for all endpoints 