### PR TITLE
Fix `IndexError` when Hypothesis found inconsistent test results during the test execution in runner

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- ``IndexError`` when Hypothesis found inconsistent test results during the test execution in runner. `#236`_
+
 `0.13.1`_ - 2019-11-05
 ----------------------
 
@@ -349,6 +354,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#237: https://github.com/kiwicom/schemathesis/issues/237
+.. _#236: https://github.com/kiwicom/schemathesis/issues/236
 .. _#216: https://github.com/kiwicom/schemathesis/issues/216
 .. _#215: https://github.com/kiwicom/schemathesis/issues/215
 .. _#214: https://github.com/kiwicom/schemathesis/issues/214

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -87,7 +87,11 @@ def execute_from_schema(
             except hypothesis.errors.Flaky:
                 status = Status.error
                 result.mark_errored()
-                flaky_example = result.checks[-1].example
+                # Sometimes Hypothesis detects inconsistent test results and checks are not available
+                if result.checks:
+                    flaky_example = result.checks[-1].example
+                else:
+                    flaky_example = None
                 result.add_error(
                     hypothesis.errors.Flaky(
                         "Tests on this endpoint produce unreliable results: \n"

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -77,7 +77,8 @@ def capture_hypothesis_output() -> Generator[List[str], None, None]:
                 "Falsifying example: ",
                 "You can add @seed",
                 "Failed to reproduce exception. Expected:",
-                "Flaky example! Hypothesis",
+                "Flaky example!",
+                "Inconsistent test results!",
             )
         ):
             return


### PR DESCRIPTION
Fixes #236 