### PR TITLE
Display seed in the CLI output.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Display RNG seed in the CLI output to allow test reproducing. `#267`_
+- Allow to specify seed in CLI.
+
 `0.15.0`_ - 2019-11-15
 ----------------------
 
@@ -404,6 +410,7 @@ Fixed
 .. _#272: https://github.com/kiwicom/schemathesis/issues/272
 .. _#270: https://github.com/kiwicom/schemathesis/issues/270
 .. _#268: https://github.com/kiwicom/schemathesis/issues/268
+.. _#267: https://github.com/kiwicom/schemathesis/issues/267
 .. _#261: https://github.com/kiwicom/schemathesis/issues/261
 .. _#256: https://github.com/kiwicom/schemathesis/issues/256
 .. _#254: https://github.com/kiwicom/schemathesis/issues/254

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -19,10 +19,14 @@ from .models import Case, Endpoint, empty_object
 PARAMETERS = frozenset(("path_parameters", "headers", "cookies", "query", "body", "form_data"))
 
 
-def create_test(endpoint: Endpoint, test: Callable, settings: Optional[hypothesis.settings] = None) -> Callable:
+def create_test(
+    endpoint: Endpoint, test: Callable, settings: Optional[hypothesis.settings] = None, seed: Optional[int] = None
+) -> Callable:
     """Create a Hypothesis test."""
     strategy = endpoint.as_strategy()
     wrapped_test = hypothesis.given(case=strategy)(test)
+    if seed is not None:
+        wrapped_test = hypothesis.seed(seed)(wrapped_test)
     original_test = get_original_test(test)
     if asyncio.iscoroutinefunction(original_test):
         wrapped_test.hypothesis.inner_test = make_async_test(original_test)  # type: ignore

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -92,6 +92,7 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
 @click.option(
     "--hypothesis-report-multiple-bugs", help="Raise only the exception with the smallest minimal example.", type=bool
 )
+@click.option("--hypothesis-seed", help="Set a seed to use for all Hypothesis tests.", type=int)
 @click.option(
     "--hypothesis-suppress-health-check",
     help="Comma-separated list of health checks to disable.",
@@ -120,6 +121,7 @@ def run(  # pylint: disable=too-many-arguments
     hypothesis_phases: Optional[List[hypothesis.Phase]] = None,
     hypothesis_report_multiple_bugs: Optional[bool] = None,
     hypothesis_suppress_health_check: Optional[List[hypothesis.HealthCheck]] = None,
+    hypothesis_seed: Optional[int] = None,
     hypothesis_verbosity: Optional[hypothesis.Verbosity] = None,
 ) -> None:
     """Perform schemathesis test against an API specified by SCHEMA.
@@ -145,6 +147,7 @@ def run(  # pylint: disable=too-many-arguments
             suppress_health_check=hypothesis_suppress_health_check,
             verbosity=hypothesis_verbosity,
         ),
+        seed=hypothesis_seed,
     )
 
     with abort_on_network_errors():

--- a/src/schemathesis/cli/output.py
+++ b/src/schemathesis/cli/output.py
@@ -171,7 +171,7 @@ def display_single_error(result: TestResult) -> None:
         message = utils.format_exception(error)
         click.secho(message, fg="red")
         if example is not None:
-            display_example(example)
+            display_example(example, seed=result.seed)
 
 
 def display_failures(results: TestResultSet) -> None:
@@ -193,14 +193,16 @@ def display_single_failure(result: TestResult) -> None:
     display_subsection(result)
     for check in reversed(result.checks):
         if check.example is not None:
-            display_example(check.example, check.name, check.message)
+            display_example(check.example, check.name, check.message, result.seed)
             # Display only the latest case
             # (dd): It is possible to find multiple errors, but the simplest option for now is to display
             # the latest and avoid deduplication, which will be done in the future.
             break
 
 
-def display_example(case: Case, check_name: Optional[str] = None, message: Optional[str] = None) -> None:
+def display_example(
+    case: Case, check_name: Optional[str] = None, message: Optional[str] = None, seed: Optional[int] = None
+) -> None:
     if message is not None:
         click.secho(message, fg="red")
         click.echo()
@@ -211,6 +213,8 @@ def display_example(case: Case, check_name: Optional[str] = None, message: Optio
     }
     max_length = max(map(len, output))
     template = f"{{:<{max_length}}} : {{}}"
+    if seed is not None:
+        click.secho(template.format("Used seed", seed), fg="red")
     if check_name is not None:
         click.secho(template.format("Check", check_name), fg="red")
     for key, value in output.items():

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -147,6 +147,7 @@ class TestResult:
     checks: List[Check] = attr.ib(factory=list)  # pragma: no mutate
     errors: List[Tuple[Exception, Optional[Case]]] = attr.ib(factory=list)  # pragma: no mutate
     is_errored: bool = attr.ib(default=False)  # pragma: no mutate
+    seed: Optional[int] = attr.ib(default=None)  # pragma: no mutate
 
     def mark_errored(self) -> None:
         self.is_errored = True

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -165,6 +165,7 @@ def execute_from_schema(
             except Exception as error:
                 status = Status.error
                 result.add_error(error)
+            result.seed = getattr(test, "_hypothesis_internal_use_generated_seed", None)
             results.append(result)
             yield events.AfterExecution(results=results, schema=schema, endpoint=endpoint, status=status)
 

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -76,13 +76,13 @@ class BaseSchema(Mapping):
         raise NotImplementedError
 
     def get_all_tests(
-        self, func: Callable, settings: Optional[hypothesis.settings] = None
+        self, func: Callable, settings: Optional[hypothesis.settings] = None, seed: Optional[int] = None
     ) -> Generator[Tuple[Endpoint, Union[Callable, InvalidSchema]], None, None]:
         """Generate all endpoints and Hypothesis tests for them."""
         test: Union[Callable, InvalidSchema]
         for endpoint in self.get_all_endpoints():
             try:
-                test = create_test(endpoint, func, settings)
+                test = create_test(endpoint, func, settings, seed=seed)
             except InvalidSchema as exc:
                 test = exc
             yield endpoint, test

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -122,6 +122,7 @@ def test_commands_run_help(cli):
         "  --hypothesis-report-multiple-bugs BOOLEAN",
         "                                  Raise only the exception with the smallest",
         "                                  minimal example.",
+        "  --hypothesis-seed INTEGER       Set a seed to use for all Hypothesis tests.",
         "  --hypothesis-suppress-health-check [data_too_large|filter_too_much|too_slow|return_value|"
         "hung_test|large_base_example|not_a_test_method]",
         "                                  Comma-separated list of health checks to",
@@ -170,6 +171,7 @@ SCHEMA_URI = "https://example.com/swagger.json"
             [SCHEMA_URI, "--base-url=https://example.com/api/v1test"],
             {"checks": DEFAULT_CHECKS, "loader_options": {"base_url": "https://example.com/api/v1test"}},
         ),
+        ([SCHEMA_URI, "--hypothesis-seed=123"], {"checks": DEFAULT_CHECKS, "seed": 123}),
         (
             [
                 SCHEMA_URI,
@@ -338,6 +340,15 @@ def test_default_hypothesis_settings(cli, schema_url):
     assert result.exit_code == ExitCode.OK
     assert "GET /api/success ." in result.stdout
     assert "GET /api/slow ." in result.stdout
+
+
+@pytest.mark.endpoints("failure")
+def test_seed(cli, schema_url):
+    # When there is a failure
+    result = cli.run(schema_url, "--hypothesis-seed=456")
+    # Then the tests should fail and RNG seed should be displayed
+    assert result.exit_code == 1
+    assert "Used seed       : 456" in result.stdout
 
 
 @pytest.mark.endpoints("unsatisfiable")

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -384,7 +384,7 @@ def test_flaky(cli, schema_url):
 @pytest.mark.endpoints("invalid")
 def test_invalid_endpoint(cli, schema_url):
     # When the app's schema contains errors
-    # For example if it type is "int" but should be "integer"
+    # For example if its type is "int" but should be "integer"
     result = cli.run(schema_url)
     # Then the whole Schemathesis run should fail
     assert result.exit_code == ExitCode.TESTS_FAILED

--- a/test/cli/test_output.py
+++ b/test/cli/test_output.py
@@ -260,7 +260,7 @@ def test_display_failures(swagger_20, capsys, results_set):
 
 def test_display_errors(swagger_20, capsys, results_set):
     # Given two test results - success and error
-    error = models.TestResult(models.Endpoint("/api/error", "GET", {}), swagger_20)
+    error = models.TestResult(models.Endpoint("/api/error", "GET", {}), swagger_20, seed=123)
     error.add_error(
         ConnectionError("Connection refused!"),
         models.Case("/api/error", "GET", base_url="http://127.0.0.1:8080", query={"a": 1}),
@@ -276,6 +276,7 @@ def test_display_errors(swagger_20, capsys, results_set):
     # And the error itself is displayed
     assert "ConnectionError: Connection refused!" in out
     # And the example is displayed
+    assert "Used seed       : 123" in out
     assert "Query           : {'a': 1}" in out
 
 


### PR DESCRIPTION
Closes #267 

Output example:
```
=== ERRORS ===
____ GET: /api/flaky ____
hypothesis.errors.Flaky: Tests on this endpoint produce unreliable results: 
Falsified on the first call but did not on a subsequent one

Used seed       : 246442565675977375928223543448485731889
Query           : {'id': 0}

Run this Python code to reproduce this failure: 

requests.get('http://127.0.0.1:8081/api/flaky', params={'id': 0})
=== FAILURES ===
___ GET: /api/failure ____
Received a response with 5xx status code: 500

Used seed       : 313022266096038506880814748301664910156
Check           : not_a_server_error

Run this Python code to reproduce this failure: 

requests.get('http://127.0.0.1:8081/api/failure')
```