### PR TITLE
Fix pytest fixtures parametrization via `pytest_generate_tests` hook

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -383,7 +383,8 @@ Fixed
 
 - Initial public release
 
-.. _Unreleased: https://github.com/kiwicom/schemathesis/compare/v0.14.0...HEAD
+.. _Unreleased: https://github.com/kiwicom/schemathesis/compare/v0.15.0...HEAD
+.. _0.15.0: https://github.com/kiwicom/schemathesis/compare/v0.14.0...v0.15.0
 .. _0.14.0: https://github.com/kiwicom/schemathesis/compare/v0.13.2...v0.14.0
 .. _0.13.2: https://github.com/kiwicom/schemathesis/compare/v0.13.1...v0.13.2
 .. _0.13.1: https://github.com/kiwicom/schemathesis/compare/v0.13.0...v0.13.1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ Added
 - Display RNG seed in the CLI output to allow test reproducing. `#267`_
 - Allow to specify seed in CLI.
 
+Fixed
+~~~~~
+
+- Pytest fixture parametrization via ``pytest_generate_tests``. `#280`_
+
 `0.15.0`_ - 2019-11-15
 ----------------------
 
@@ -408,6 +413,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#280: https://github.com/kiwicom/schemathesis/issues/280
 .. _#272: https://github.com/kiwicom/schemathesis/issues/272
 .. _#270: https://github.com/kiwicom/schemathesis/issues/270
 .. _#268: https://github.com/kiwicom/schemathesis/issues/268

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -117,7 +117,9 @@ def get_case_strategy(endpoint: Endpoint) -> st.SearchStrategy:
     static_kwargs = {"path": endpoint.path, "method": endpoint.method, "base_url": endpoint.base_url}
     try:
         strategies = {
-            "path_parameters": from_schema(endpoint.path_parameters).filter(filter_path_parameters).map(quote_all),
+            "path_parameters": from_schema(endpoint.path_parameters)
+            .filter(filter_path_parameters)  # type: ignore
+            .map(quote_all),  # type: ignore
             "headers": from_schema(endpoint.headers).filter(is_valid_header),  # type: ignore
             "cookies": from_schema(endpoint.cookies),
             "query": from_schema(endpoint.query),

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -1,0 +1,31 @@
+def test_pytest_parametrize_fixture(testdir):
+    # When `pytest_generate_tests` is used on a module level for fixture parametrization
+    testdir.make_test(
+        """
+def pytest_generate_tests(metafunc):
+    metafunc.parametrize("inner", ("A", "B"))
+
+@pytest.fixture()
+def param(inner):
+    return inner * 2
+
+@schema.parametrize()
+def test_(request, param, case):
+    request.config.HYPOTHESIS_CASES += 1
+    assert case.path == "/v1/users"
+    assert case.method in ("GET", "POST")
+""",
+        paths={"/users": {"get": {}, "post": {}}},
+    )
+    # And there are multiple method/endpoint combinations
+    result = testdir.runpytest("-v", "-s")
+    # Then the total number of tests should be Method/Endpoint combos x parameters in `pytest_generate_tests`
+    # I.e. regular pytest parametrization logic should be applied
+    result.assert_outcomes(passed=4)
+    result.stdout.re_match_lines(
+        [
+            r"test_pytest_parametrize_fixture.py::test_\[GET:/v1/users\]\[A\] PASSED",
+            r"test_pytest_parametrize_fixture.py::test_\[GET:/v1/users\]\[B\] PASSED",
+            r"Hypothesis calls: 4",
+        ]
+    )


### PR DESCRIPTION
Fixes #280 