### PR TITLE
Fix unclosed `requests.Session` on calling `Case.call` without passing a session explicitly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Fixed
 
 - Pytest fixture parametrization via ``pytest_generate_tests``. `#280`_
 - Support for tests defined as methods. `#282`_
+- Unclosed ``requests.Session`` on calling ``Case.call`` without passing a session explicitly. `#286`_
 
 `0.15.0`_ - 2019-11-15
 ----------------------
@@ -414,6 +415,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#286: https://github.com/kiwicom/schemathesis/issues/286
 .. _#282: https://github.com/kiwicom/schemathesis/issues/282
 .. _#280: https://github.com/kiwicom/schemathesis/issues/280
 .. _#272: https://github.com/kiwicom/schemathesis/issues/272

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -89,10 +89,16 @@ class Case:
         """Convert the case into a dictionary acceptable by requests."""
         if session is None:
             session = requests.Session()
+            close_session = True
+        else:
+            close_session = False
 
         base_url = self._get_base_url(base_url)
         data = self.as_requests_kwargs(base_url)
-        return session.request(**data, **kwargs)  # type: ignore
+        response = session.request(**data, **kwargs)  # type: ignore
+        if close_session:
+            session.close()
+        return response
 
 
 def empty_object() -> Dict[str, Any]:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -34,6 +34,7 @@ def test_as_requests_kwargs(override, server, base_url, converter):
 
 
 @pytest.mark.parametrize("override", (False, True))
+@pytest.mark.filterwarnings("always")
 def test_call(override, base_url):
     kwargs = {"method": "GET", "path": "/api/success"}
     if override:
@@ -44,6 +45,9 @@ def test_call(override, base_url):
         response = case.call()
     assert response.status_code == 200
     assert response.json() == {"success": True}
+    with pytest.warns(None) as records:
+        del response
+    assert not records
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix #286 