### PR TITLE
build(docker): Make image more usable in CI environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,4 @@
-**/.dockerignore
-**/.env
-**/.git
-**/.gitignore
-**/docker-compose*
-**/Dockerfile*
-**/docs
-**/img
-**/test
-LICENSE
+*
+!poetry.lock
+!pyproject.toml
+!src/schemathesis

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,22 @@ FROM python:3.8-alpine
 
 LABEL Name=Schemathesis
 
-RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip --no-cache-dir install poetry
-
+ENV BINPATH=/usr/local/bin
 WORKDIR /app
+
 RUN addgroup -S schemathesis && \
     adduser -D -S schemathesis -G schemathesis -s /sbin/nologin && \
-    chown schemathesis:schemathesis /app -R
-USER schemathesis
-COPY --chown=schemathesis:schemathesis ./poetry.lock ./pyproject.toml ./README.rst ./src ./
-RUN poetry install --no-dev
+    apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev && \
+    pip install --no-cache-dir poetry==1.0.0b5 && \
+    apk del .build-deps && \
+    printf '#!/bin/sh\n(cd /app && poetry run schemathesis $@)' > $BINPATH/schemathesis && \
+    chmod +x $BINPATH/schemathesis
 
-ENTRYPOINT ["poetry", "run", "schemathesis"]
+USER schemathesis
+
+COPY poetry.lock pyproject.toml ./
+RUN poetry install --no-dev --no-root
+COPY src ./
+
+ENTRYPOINT ["schemathesis"]
 CMD [ "--help" ]


### PR DESCRIPTION
* Improve caching by just copying essential files for each stage
* Group RUN commands in as few layers as possible
* Use `poetry==1.0.0b5`, which allows avoiding the installation of the local package
* Generate `schemathesis` comand, globally accessible
* Use whitelist approach for `.dockerignore`

Apologies for not noticing that it wouldn't be easy to run it on CI during my first review

I don't fully like the solution, but unfortunately `poetry` is not yet ready for using it comfortably outside of the dev environment. Personally, when I've used poetry in the past I just ended up generating a `requirements.txt` and using that in the docker image instead... but with this changes it's enough to make it usable both in CI and locally

locally, nothing changed:
```bash
docker run --rm kiwicom/schemathesis run http://localhost/openapi.json
```

In (gitlab) CI:
```yaml
schemathesis
  image:
    name: kiwicom/schemathesis
    entrypoint: [""]
  stage: test
  services:
    - name: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
      alias: backend
  script:
    - schemathesis run --base-url=http://backend$ENDPOINT $SCHEMA
```