### PR TITLE
CI: Refator CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,116 +1,114 @@
-name: build
+name: Build jobs
+# Triggered by changes in code-specific or job-specific files
 
 on:
   pull_request:
     paths:
-      - '**.py'
-      - '!docs/**'
-      - '!adr/**'
+       - '**.py'
+       - '.github/workflows/*.yml'
+       - '.pylintrc'
+       - 'poetry.lock'
+       - 'pyproject.toml'
+       - 'tox.ini'
+       - 'mypy.ini'
+       - '!docs/**'
+       - '!adr/**'
   push:
     branches:
       - master
 
 jobs:
-  black:
-    name: black
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: docker://kiwicom/black
-      with:
-        args: black --check --diff .
-        
-        
-  commitsar:
-    name: Verify commit messages
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v1
-      - name: Run commitsar
-        uses: docker://commitsar/commitsar
+   black:
+     name: black
+     runs-on: ubuntu-latest
+     steps:
+     - uses: actions/checkout@v1
+       with:
+        fetch-depth: 1
+     - uses: docker://kiwicom/black
+       with:
+         args: black --check --diff .
 
-  pylint:
-    name: pylint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-    - run: pip install poetry
-    - run: poetry add pylint
-    - run: poetry install
-    - run: poetry run pylint src/schemathesis
 
-  mypy:
-    name: mypy
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: docker://kiwicom/mypy
-      with:
-        args: mypy src/schemathesis
+   pylint:
+     name: pylint
+     runs-on: ubuntu-latest
+     steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
 
-  py36:
-    name: py36
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.6'
-    - run: pip install tox coverage
-    - run: tox -e py36
-    - run: coverage combine
-    - run: coverage report
-    - run: coverage xml -i
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.2
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-py36
+     - uses: actions/setup-python@v1
+       with:
+         python-version: '3.8'
 
-  py37:
-    name: py37
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-    - run: pip install tox coverage
-    - run: tox -e py37
-    - run: coverage combine
-    - run: coverage report
-    - run: coverage xml -i
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.2
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-py37
+     - run: pip install poetry
 
-  py38:
-    name: py38
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.8'
-    - run: pip install tox coverage
-    - run: tox -e py38
-    - run: coverage combine
-    - run: coverage report
-    - run: coverage xml -i
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.2
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-py38
+     - name: Cache Poetry virtualenv
+       uses: actions/cache@v1
+       id: cache
+       with:
+         path: ~/.virtualenvs
+         key: poetry-${{ hashFiles('**/poetry.lock') }}
+         restore-keys: |
+           poetry-${{ hashFiles('**/poetry.lock') }}
+
+     - name: Set Poetry config
+       run: |
+         poetry config settings.virtualenvs.in-project false
+         poetry config settings.virtualenvs.path ~/.virtualenvs
+
+     - run: poetry add pylint
+
+     - run: poetry install
+       if: steps.cache.outputs.cache-hit != 'true'
+
+     - run: poetry run pylint src/schemathesis
+
+
+   mypy:
+     name: mypy
+     runs-on: ubuntu-latest
+     steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: docker://kiwicom/mypy
+       with:
+         args: mypy src/schemathesis
+
+
+   tests:
+     strategy:
+       matrix:
+         python: [3.6, 3.7, 3.8]
+
+     name: tests_${{ matrix.python }}
+     runs-on: ubuntu-latest
+     steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+
+     - uses: actions/setup-python@v1
+       with:
+         python-version: ${{ matrix.python }}
+
+     - run: pip install tox coverage
+
+     - name: Run ${{ matrix.python }} tox job
+       run: tox -e py${TOX_JOB//.} # Strip dot from python version to match tox job
+       env:
+         TOX_JOB: ${{ matrix.python }}
+
+     - run: coverage combine
+     - run: coverage report
+     - run: coverage xml -i
+
+     - name: Upload coverage to Codecov
+       uses: codecov/codecov-action@v1.0.2
+       with:
+         token: ${{secrets.CODECOV_TOKEN}}
+         file: ./coverage.xml
+         flags: unittests
+         name: codecov-py36

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,18 @@
+name: Checks for every commit
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+
+
+jobs:
+  commitsar:
+    name: Verify commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Run commitsar
+        uses: docker://commitsar/commitsar

--- a/.github/workflows/master_update.yml
+++ b/.github/workflows/master_update.yml
@@ -1,4 +1,4 @@
-name: Post-update master actions
+name: Post-update master jobs
 
 on:
   push:
@@ -10,13 +10,18 @@ jobs:
     name: Build and publish to Docker Hub
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+
     - name: Build the image
       run: docker build -f "Dockerfile" -t "kiwicom/schemathesis:latest" .
+
     - name: Login to registry
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     - name: Publish latest image
       run: docker push kiwicom/schemathesis:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,50 +1,66 @@
-name: Post-release actions
+name: Post-release jobs
 
 on:
   release:
-    type: [published, edited]
+    type: [published]
 
 jobs:
   release_image:
     name: Build and publish to Docker Hub
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+
     - name: Build the image
       run: docker build -f "Dockerfile" -t "kiwicom/schemathesis:${GITHUB_REF##*/}" -t "kiwicom/schemathesis:stable" .
+
     - name: Login to registry
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: Publish stable image
-      run: docker push kiwicom/schemathesis:${GITHUB_REF##*/}
+
     - name: Publish tag image
+      run: docker push kiwicom/schemathesis:${GITHUB_REF##*/}
+
+    - name: Publish stable image
       run: docker push kiwicom/schemathesis:stable
+
 
   release_package:
     name: Build and publish package to pypi.org
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.8'
+
     - run: pip install poetry
+
     - name: Build package
       run: poetry build --no-interaction
+
     - name: Publish package
       run: poetry publish --no-interaction --username=${PYPI_USERNAME} --password=${PYPI_PASSWORD}
       env:
         PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        
+
+
   release-notes:
     name: Release Notes
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
 
       - name: Release Notary Action
         uses: docker://commitsar/release-notary

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,44 +1,58 @@
-name: scheduled
+name: Scheduled jobs
 
 on:
   schedule:
-    # Every Monday at 00:00
-    # - cron: "0 0 * * 1"
-    - cron: "0 13  * * 3"
+     # Every Monday at 00:00
+     - cron: "0 0 * * 1"
 
 jobs:
   mutmut:
     name: mutmut
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+
     - uses: actions/setup-python@v1
       with:
         python-version: '3.8'
+
     - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends sqlite3
+
     - run: pip install poetry mutmut
+
+    - name: Cache Poetry virtualenv
+      uses: actions/cache@v1
+      id: cache
+      with:
+        path: ~/.virtualenvs
+        key: poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          poetry-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Set Poetry config
+      run: |
+        poetry config settings.virtualenvs.in-project false
+        poetry config settings.virtualenvs.path ~/.virtualenvs
+
     - run: poetry install
-    # Run mutmut
-    # If exit code is 0, finish the job
-    # Else ignore exit code and extract mutant ids
-    #  If no id is found, then exit with exit code 0
-    #  Else run `mutmut show $id` and exit with exit code 1 to fail the job
-    #  and make failure more visible
-    - run:
+      if: steps.cache.outputs.cache-hit != 'true'
+
+    - name: Run mutmut tests
+      run:
         mutmut run
           --backup
           --paths-to-mutate "src/"
           --tests-dir "test/"
           --runner "poetry run pytest -n auto -x --tb=no -q"
-        ||
+
+    - name: Display survived mutations
+      if: failure()
+      run:
         while read -r line;
-          do
-            if [[ -n $line ]];
-              then EXIT=false; mutmut show $line;
-              else EXIT=true;
-            fi;
+          do mutmut show $line;
         done <<< $(
           sqlite3 .mutmut-cache
             "select id from Mutant where status in ('bad_survived', 'bad_timeout', 'ok_suspicious');"
           );
-        $EXIT


### PR DESCRIPTION
Changes:
- Separated workflow for jobs that must run for change in every file (commitsar only for now)
- Updated list of files that trigger build jobs 
- Use stable version of [checkout](https://github.com/actions/checkout) action instead of master.
- Use Python 3.8 for job where it is relevant
- Use shallow clone of schemathesis repository via checkout action to reduce cloning time
- Cache poetry virtualenv where it is possible
- Use matrix to use only one parametrized tox job.
- Trigger release jobs only on published releases. Looks like `edited` release triggers only when title/description is changes, tag change creates another release event.
- Use `steps.if` syntax to decrease mumut job complexity. Behavior is the same: mutations will be displayed only if `mutmut run` step exited with non-zero code and overall job will be failed, otherwise passed.