### PR TITLE
Concurrent test execution in CLI / runner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,14 @@ CLI supports passing options to ``hypothesis.settings``. All of them are prefixe
 
     schemathesis run --hypothesis-max-examples=1000 https://example.com/api/swagger.json
 
+To speed up the testing process Schemathesis provides ``-w/--workers`` option for concurrent test execution:
+
+.. code:: bash
+
+    schemathesis run -w 8 https://example.com/api/swagger.json
+
+In the example above all tests will be distributed among 8 worker threads.
+
 For the full list of options, run:
 
 .. code:: bash

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Concurrent test execution in CLI / runner. `#91`_
+
 `0.18.1`_ - 2019-11-28
 ----------------------
 
@@ -531,6 +536,7 @@ Fixed
 .. _#98: https://github.com/kiwicom/schemathesis/issues/98
 .. _#94: https://github.com/kiwicom/schemathesis/issues/94
 .. _#92: https://github.com/kiwicom/schemathesis/issues/92
+.. _#91: https://github.com/kiwicom/schemathesis/issues/91
 .. _#90: https://github.com/kiwicom/schemathesis/issues/90
 .. _#78: https://github.com/kiwicom/schemathesis/issues/78
 .. _#75: https://github.com/kiwicom/schemathesis/issues/75

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -135,7 +135,7 @@ def get_case_strategy(endpoint: Endpoint) -> st.SearchStrategy:
             if value is not None:
                 if parameter == "path_parameters":
                     strategies[parameter] = (
-                        from_schema(value).filter(filter_path_parameters).map(quote_all)  # type: ignore  # type: ignore
+                        from_schema(value).filter(filter_path_parameters).map(quote_all)  # type: ignore
                     )
                 elif parameter == "headers":
                     strategies[parameter] = from_schema(value).filter(is_valid_header)  # type: ignore

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -225,7 +225,6 @@ class OutputStyle(Enum):
 def execute(prepared_runner: Generator[events.ExecutionEvent, None, None], workers_num: int) -> None:
     """Execute a prepared runner by drawing events from it and passing to a proper handler."""
     handler = get_output_handler(workers_num)
-    with utils.capture_hypothesis_output() as hypothesis_output:
-        context = events.ExecutionContext(hypothesis_output, workers_num)
-        for event in prepared_runner:
-            handler(context, event)
+    context = events.ExecutionContext(workers_num=workers_num)
+    for event in prepared_runner:
+        handler(context, event)

--- a/src/schemathesis/cli/output/__init__.py
+++ b/src/schemathesis/cli/output/__init__.py
@@ -1,1 +1,1 @@
-from . import default
+from . import default, short

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -235,6 +235,7 @@ def handle_initialized(context: events.ExecutionContext, event: events.Initializ
     if event.schema.base_url is not None:
         click.echo(f"Base URL: {event.schema.base_url}")
     click.echo(f"Specification version: {event.schema.verbose_name}")
+    click.echo(f"Workers: {context.workers_num}")
     click.secho(f"collected endpoints: {event.schema.endpoints_count}", bold=True)
     if event.schema.endpoints_count >= 1:
         click.echo()

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -278,6 +278,7 @@ def handle_event(context: events.ExecutionContext, event: events.ExecutionEvent)
     if isinstance(event, events.BeforeExecution):
         handle_before_execution(context, event)
     if isinstance(event, events.AfterExecution):
+        context.hypothesis_output.extend(event.hypothesis_output)
         handle_after_execution(context, event)
     if isinstance(event, events.Finished):
         handle_finished(context, event)

--- a/src/schemathesis/cli/output/short.py
+++ b/src/schemathesis/cli/output/short.py
@@ -19,6 +19,7 @@ def handle_event(context: events.ExecutionContext, event: events.ExecutionEvent)
     if isinstance(event, events.Initialized):
         default.handle_initialized(context, event)
     if isinstance(event, events.AfterExecution):
+        context.hypothesis_output.extend(event.hypothesis_output)
         handle_after_execution(context, event)
     if isinstance(event, events.Finished):
         default.handle_finished(context, event)

--- a/src/schemathesis/cli/output/short.py
+++ b/src/schemathesis/cli/output/short.py
@@ -1,0 +1,26 @@
+import click
+
+from ...runner import events
+from . import default
+
+
+def handle_after_execution(context: events.ExecutionContext, event: events.AfterExecution) -> None:
+    context.endpoints_processed += 1
+    default.display_execution_result(context, event)
+    if context.endpoints_processed == event.schema.endpoints_count:
+        click.echo()
+
+
+def handle_event(context: events.ExecutionContext, event: events.ExecutionEvent) -> None:
+    """Short output style shows single symbols in the progress bar.
+
+    Otherwise, identical to the default output style.
+    """
+    if isinstance(event, events.Initialized):
+        default.handle_initialized(context, event)
+    if isinstance(event, events.AfterExecution):
+        handle_after_execution(context, event)
+    if isinstance(event, events.Finished):
+        default.handle_finished(context, event)
+    if isinstance(event, events.Interrupted):
+        default.handle_interrupted(context, event)

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -14,7 +14,7 @@ from ..schemas import BaseSchema
 class ExecutionContext:
     """Storage for the current context of the execution."""
 
-    hypothesis_output: List[str] = attr.ib()  # pragma: no mutate
+    hypothesis_output: List[str] = attr.ib(factory=list)  # pragma: no mutate
     workers_num: int = attr.ib(default=1)  # pragma: no mutate
     endpoints_processed: int = attr.ib(default=0)  # pragma: no mutate
     current_line_length: int = attr.ib(default=0)  # pragma: no mutate
@@ -45,6 +45,7 @@ class BeforeExecution(ExecutionEvent):
 class AfterExecution(ExecutionEvent):
     endpoint: Endpoint = attr.ib()  # pragma: no mutate
     status: Status = attr.ib()  # pragma: no mutate
+    hypothesis_output: List[str] = attr.ib(factory=list)  # pragma: no mutate
 
 
 @attr.s(slots=True)  # pragma: no mutate

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -15,6 +15,7 @@ class ExecutionContext:
     """Storage for the current context of the execution."""
 
     hypothesis_output: List[str] = attr.ib()  # pragma: no mutate
+    workers_num: int = attr.ib(default=1)  # pragma: no mutate
     endpoints_processed: int = attr.ib(default=0)  # pragma: no mutate
     current_line_length: int = attr.ib(default=0)  # pragma: no mutate
     terminal_size: os.terminal_size = attr.ib(factory=shutil.get_terminal_size)  # pragma: no mutate

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -23,7 +23,7 @@ from requests.structures import CaseInsensitiveDict
 from schemathesis.exceptions import InvalidSchema
 from schemathesis.models import empty_object
 
-from ._hypothesis import create_test
+from ._hypothesis import make_test_or_exception
 from .filters import should_skip_by_tag, should_skip_endpoint, should_skip_method
 from .models import Endpoint
 from .types import Filter
@@ -91,10 +91,7 @@ class BaseSchema(Mapping):
         """Generate all endpoints and Hypothesis tests for them."""
         test: Union[Callable, InvalidSchema]
         for endpoint in self.get_all_endpoints():
-            try:
-                test = create_test(endpoint, func, settings, seed=seed)
-            except InvalidSchema as exc:
-                test = exc
+            test = make_test_or_exception(endpoint, func, settings, seed)
             yield endpoint, test
 
     def parametrize(

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -54,6 +54,14 @@ def dict_not_none_values(**kwargs: Any) -> Mapping[str, Any]:
     return {key: value for key, value in kwargs.items() if value is not None}
 
 
+IGNORED_PATTERNS = (
+    "Falsifying example: ",
+    "You can add @seed",
+    "Failed to reproduce exception. Expected:",
+    "Flaky example!",
+)
+
+
 @contextmanager
 def capture_hypothesis_output() -> Generator[List[str], None, None]:
     """Capture all output of Hypothesis into a list of strings.
@@ -74,9 +82,7 @@ def capture_hypothesis_output() -> Generator[List[str], None, None]:
 
     def get_output(value: str) -> None:
         # Drop messages that could be confusing in the Schemathesis context
-        if value.startswith(
-            ("Falsifying example: ", "You can add @seed", "Failed to reproduce exception. Expected:", "Flaky example!")
-        ):
+        if value.startswith(IGNORED_PATTERNS):
             return
         output.append(value)
 


### PR DESCRIPTION
Resolves #91 

It is a very rough draft

TODO:

- [x] Display number of workers in the CLI output
- [x] Add option to the CLI
- [x] Add different output styles. For concurrent execution, we can do the same as `pytest-xdist` and display only resulting symbols (e.g. `F`, or `.`)
- [x] Handle main thread interruptions
- [x] Handle interruptions in non-main threads
- [x] Check how not handled exceptions will be displayed in worker threads;
- [x] Move Hypothesis output that happens in worker threads to the main thread;
- [x] Test things 
- [x] Docs

Probably more TODO things to come

Some benchmark of our internal service (6 endpoints):

- master branch - 158.54 seconds
- this branch - 53.4 sec in 6 worker threads