### PR TITLE
chore(ci): Remove git depth limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
 
       - name: Release Notary Action
         uses: docker://outillage/release-notary


### PR DESCRIPTION
This is what is causing the releases to have a single entry