### PR TITLE
Failing tests on Mac

### DIFF
--- a/test/apps/_flask/__init__.py
+++ b/test/apps/_flask/__init__.py
@@ -71,7 +71,7 @@ def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> Flask:
     @app.route("/api/multipart", methods=["POST"])
     def multipart():
         files = {name: value.stream.read().decode() for name, value in request.files.items()}
-        return jsonify(**files, **request.form)
+        return jsonify(**files, **request.form.to_dict())
 
     @app.route("/api/teapot", methods=["POST"])
     def teapot():


### PR DESCRIPTION
Don't know the root cause, but on Linux the values are not in list,
not checked the package versions precisely yet, but this check doesn't make harm
It seems that this conversion happens implicitly somewhere