### PR TITLE
Make schemas in tests compliant to the spec

### DIFF
--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -51,38 +51,53 @@ def make_schema(endpoints: Tuple[str, ...]) -> Dict:
                         # Impossible to satisfy
                         "schema": {"allOf": [{"type": "integer"}, {"type": "string"}]},
                     }
-                ]
+                ],
+                "responses": {"200": {"description": "OK"}},
             }
         elif endpoint in ("flaky", "multiple_failures"):
-            schema = {"parameters": [{"name": "id", "in": "query", "required": True, "type": "integer"}]}
+            schema = {
+                "parameters": [{"name": "id", "in": "query", "required": True, "type": "integer"}],
+                "responses": {"200": {"description": "OK"}},
+            }
         elif endpoint == "path_variable":
             schema = {
                 "parameters": [{"name": "key", "in": "path", "required": True, "type": "string", "minLength": 1}],
-                "responses": {200: {"description": "OK"}},
+                "responses": {"200": {"description": "OK"}},
             }
         elif endpoint == "invalid":
-            schema = {"parameters": [{"name": "id", "in": "query", "required": True, "type": "int"}]}
+            schema = {
+                "parameters": [{"name": "id", "in": "query", "required": True, "type": "int"}],
+                "responses": {"200": {"description": "OK"}},
+            }
         elif endpoint == "upload_file":
-            schema = {"parameters": [{"name": "data", "in": "body", "required": True, "schema": {"type": "file"}}]}
+            schema = {
+                "parameters": [{"name": "data", "in": "formData", "required": True, "type": "file"}],
+                "responses": {"200": {"description": "OK"}},
+            }
         elif endpoint == "custom_format":
             schema = {
-                "parameters": [{"name": "id", "in": "query", "required": True, "type": "string", "format": "digits"}]
+                "parameters": [{"name": "id", "in": "query", "required": True, "type": "string", "format": "digits"}],
+                "responses": {"200": {"description": "OK"}},
             }
         elif endpoint == "multipart":
             schema = {
                 "parameters": [
                     {"in": "formData", "name": "key", "required": True, "type": "string"},
                     {"in": "formData", "name": "value", "required": True, "type": "integer"},
-                ]
+                ],
+                "responses": {"200": {"description": "OK"}},
             }
         elif endpoint == "teapot":
-            schema = {"produces": ["application/json"], "responses": {200: {"description": "OK"}}}
+            schema = {"produces": ["application/json"], "responses": {"200": {"description": "OK"}}}
         elif endpoint == "invalid_path_parameter/{id}":
-            schema = {"parameters": [{"name": "id", "in": "path", "required": False, "type": "integer"}]}
+            schema = {
+                "parameters": [{"name": "id", "in": "path", "required": False, "type": "integer"}],
+                "responses": {"200": {"description": "OK"}},
+            }
         else:
             schema = {
                 "responses": {
-                    200: {
+                    "200": {
                         "description": "OK",
                         "schema": {
                             "type": "object",

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -580,7 +580,6 @@ def test_multiple_failures_different_check(cli, schema_url):
     assert "2. Received a response with 5xx status code: 500" in lines
     assert "3. Received a response with a status code, which is not defined in the schema: 504" in lines
     assert "4. Received a response with 5xx status code: 504" in lines
-    assert "5. Received a response with a status code, which is not defined in the schema: 200" in lines
     assert "1 failed in " in lines[-1]
 
 
@@ -806,17 +805,19 @@ async def test_multiple_files_schema(app, testdir, cli, base_url):
         "schemes": ["http"],
         "produces": ["application/json"],
         "paths": {
-            "teapot": {
+            "/teapot": {
                 "post": {
                     "parameters": [
                         {
-                            # during the CLI run we have a different working directory, so specifying an absolute file path
+                            # during the CLI run we have a different working directory,
+                            # so specifying an absolute file path
                             "schema": {"$ref": os.path.join(HERE, "data/petstore_v2.yaml#/definitions/Pet")},
                             "in": "body",
                             "name": "user",
                             "required": True,
                         }
-                    ]
+                    ],
+                    "responses": {"200": {"description": "OK"}},
                 }
             }
         },

--- a/test/data/petstore_v2.yaml
+++ b/test/data/petstore_v2.yaml
@@ -49,7 +49,7 @@ paths:
         schema:
           $ref: "#/definitions/Pet"
       responses:
-        405:
+        '405':
           description: "Invalid input"
       security:
       - petstore_auth:
@@ -75,11 +75,11 @@ paths:
         schema:
           $ref: "#/definitions/Pet"
       responses:
-        400:
+        '400':
           description: "Invalid ID supplied"
-        404:
+        '404':
           description: "Pet not found"
-        405:
+        '405':
           description: "Validation exception"
       security:
       - petstore_auth:
@@ -110,13 +110,13 @@ paths:
           default: "available"
         collectionFormat: "multi"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Pet"
-        400:
+        '400':
           description: "Invalid status value"
       security:
       - petstore_auth:
@@ -142,13 +142,13 @@ paths:
           type: "string"
         collectionFormat: "multi"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Pet"
-        400:
+        '400':
           description: "Invalid tag value"
       security:
       - petstore_auth:
@@ -173,13 +173,13 @@ paths:
         type: "integer"
         format: "int64"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             $ref: "#/definitions/Pet"
-        400:
+        '400':
           description: "Invalid ID supplied"
-        404:
+        '404':
           description: "Pet not found"
       security:
       - api_key: []
@@ -212,7 +212,7 @@ paths:
         required: false
         type: "string"
       responses:
-        405:
+        '405':
           description: "Invalid input"
       security:
       - petstore_auth:
@@ -239,9 +239,9 @@ paths:
         type: "integer"
         format: "int64"
       responses:
-        400:
+        '400':
           description: "Invalid ID supplied"
-        404:
+        '404':
           description: "Pet not found"
       security:
       - petstore_auth:
@@ -276,7 +276,7 @@ paths:
         required: false
         type: "file"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             $ref: "#/definitions/ApiResponse"
@@ -295,7 +295,7 @@ paths:
       - "application/json"
       parameters: []
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             type: "object"
@@ -322,11 +322,11 @@ paths:
         schema:
           $ref: "#/definitions/Order"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             $ref: "#/definitions/Order"
-        400:
+        '400':
           description: "Invalid Order"
   /store/order/{orderId}:
     get:
@@ -348,13 +348,13 @@ paths:
         minimum: 1.0
         format: "int64"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             $ref: "#/definitions/Order"
-        400:
+        '400':
           description: "Invalid ID supplied"
-        404:
+        '404':
           description: "Order not found"
     delete:
       tags:
@@ -374,9 +374,9 @@ paths:
         minimum: 1.0
         format: "int64"
       responses:
-        400:
+        '400':
           description: "Invalid ID supplied"
-        404:
+        '404':
           description: "Order not found"
   /user:
     post:
@@ -464,7 +464,7 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             type: "string"
@@ -477,7 +477,7 @@ paths:
               type: "string"
               format: "date-time"
               description: "date in UTC when token expires"
-        400:
+        '400':
           description: "Invalid username/password supplied"
   /user/logout:
     get:
@@ -510,13 +510,13 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        '200':
           description: "successful operation"
           schema:
             $ref: "#/definitions/User"
-        400:
+        '400':
           description: "Invalid username supplied"
-        404:
+        '404':
           description: "User not found"
     put:
       tags:
@@ -540,9 +540,9 @@ paths:
         schema:
           $ref: "#/definitions/User"
       responses:
-        400:
+        '400':
           description: "Invalid user supplied"
-        404:
+        '404':
           description: "User not found"
     delete:
       tags:
@@ -560,9 +560,9 @@ paths:
         required: true
         type: "string"
       responses:
-        400:
+        '400':
           description: "Invalid username supplied"
-        404:
+        '404':
           description: "User not found"
 securityDefinitions:
   petstore_auth:

--- a/test/generation/test_primitive.py
+++ b/test/generation/test_primitive.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..utils import as_param, integer, string
+from ..utils import as_param, integer
 
 
 @pytest.mark.parametrize(
@@ -44,14 +44,21 @@ def test_(case):
 @pytest.mark.parametrize(
     "parameter",
     (
-        string(name="key1", required=True),
-        string(name="key2", maxLength=5, required=True),
-        string(name="key3", minLength=5, required=True),
-        string(name="key4", pattern="ab{2}", required=True),
-        string(name="key5", minLength=3, maxLength=6, pattern="ab{2}", required=True),
-        string(name="key6", format="date", required=True),
-        string(name="key7", format="date-time", required=True),
-        string(name="key8", type="file", required=True),
+        {"name": "key1", "type": "string", "required": True, "in": "query"},
+        {"name": "key2", "type": "string", "required": True, "in": "query", "maxLength": 5},
+        {"name": "key3", "type": "string", "required": True, "in": "query", "minLength": 5},
+        {"name": "key4", "type": "string", "required": True, "in": "query", "pattern": "ab{2}"},
+        {
+            "name": "key5",
+            "type": "string",
+            "required": True,
+            "in": "query",
+            "minLength": 3,
+            "maxLength": 6,
+            "pattern": "ab{2}",
+        },
+        {"name": "key6", "type": "string", "required": True, "in": "query", "format": "date"},
+        {"name": "key7", "type": "string", "required": True, "in": "query", "format": "date-time"},
     ),
 )
 def test_string(testdir, parameter):
@@ -65,13 +72,12 @@ validator = {{
     "key5": lambda x: len(x) in (3, 4, 5, 6) and "abb" in x,
     "key6": assert_date,
     "key7": assert_datetime,
-    "key8": assert_bytes,
 }}["{name}"]
 @schema.parametrize()
 @settings(max_examples=3)
 def test_(case):
     assert case.path == "/v1/users"
-    assert case.method in ("GET", "POST")
+    assert case.method == "GET"
     validator(case.query["{name}"])
         """.format(
             name=parameter["name"]

--- a/test/test_common_parameters.py
+++ b/test/test_common_parameters.py
@@ -17,8 +17,14 @@ def test_(request, case):
         paths={
             "/users": {
                 "parameters": [integer(name="common_id", required=True)],
-                "get": {"parameters": [integer(name="not_common_id", required=True)]},
-                "post": {"parameters": [integer(name="not_common_id", required=True)]},
+                "get": {
+                    "parameters": [integer(name="not_common_id", required=True)],
+                    "responses": {"200": {"description": "OK"}},
+                },
+                "post": {
+                    "parameters": [integer(name="not_common_id", required=True)],
+                    "responses": {"200": {"description": "OK"}},
+                },
             }
         },
     )
@@ -57,11 +63,17 @@ def test_b(request, case):
                 "parameters": [
                     {"schema": {"$ref": "#/definitions/SimpleIntRef"}, "in": "body", "name": "id", "required": True}
                 ],
-                "put": {"parameters": [integer(name="not_common_id", required=True)]},
-                "post": {"parameters": [integer(name="not_common_id", required=True)]},
+                "put": {
+                    "parameters": [integer(name="not_common_id", required=True)],
+                    "responses": {"200": {"description": "OK"}},
+                },
+                "post": {
+                    "parameters": [integer(name="not_common_id", required=True)],
+                    "responses": {"200": {"description": "OK"}},
+                },
             }
         },
-        definitions={"SimpleIntRef": {"type": "integer", "name": "id"}},
+        definitions={"SimpleIntRef": {"type": "integer"}},
     )
     result = testdir.runpytest("-v", "-s")
     # Then this parameter should be used in all generated tests
@@ -90,7 +102,12 @@ def test_a(request, case):
 def test_b(request, case):
     impl(request, case)
 """,
-        paths={"/users": {"parameters": [integer(name="common_id", required=True)], "post": {}}},
+        paths={
+            "/users": {
+                "parameters": [integer(name="common_id", required=True)],
+                "post": {"responses": {"200": {"description": "OK"}}},
+            }
+        },
     )
     result = testdir.runpytest("-v", "-s")
     # Then this parameter should be used in all test functions

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -431,9 +431,7 @@ def test_(request, case):
 ROOT_SCHEMA = {
     "openapi": "3.0.2",
     "info": {"title": "Example API", "description": "An API to test Schemathesis", "version": "1.0.0"},
-    "schemes": ["http"],
-    "produces": ["application/json"],
-    "paths": {"teapot": {"$ref": "paths/teapot.yaml#/TeapotCreatePath"}},
+    "paths": {"/teapot": {"$ref": "paths/teapot.yaml#/TeapotCreatePath"}},
 }
 TEAPOT_PATHS = {
     "TeapotCreatePath": {

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -6,7 +6,7 @@ from .utils import integer
 @pytest.mark.parametrize("endpoint", ("'/foo'", "'/v1/foo'", ["/foo"], "'/.*oo'"))
 def test_endpoint_filter(testdir, endpoint):
     # When `endpoint` is specified
-    parameters = {"parameters": [integer(name="id", required=True)]}
+    parameters = {"parameters": [integer(name="id", required=True)], "responses": {"200": {"description": "OK"}}}
     testdir.make_test(
         """
 @schema.parametrize(endpoint={})
@@ -29,7 +29,7 @@ def test_(request, case):
 @pytest.mark.parametrize("method", ("'get'", "'GET'", ["GET"], ["get"]))
 def test_method_filter(testdir, method):
     # When `method` is specified
-    parameters = {"parameters": [integer(name="id", required=True)]}
+    parameters = {"parameters": [integer(name="id", required=True)], "responses": {"200": {"description": "OK"}}}
     testdir.make_test(
         """
 @schema.parametrize(method={})
@@ -53,7 +53,7 @@ def test_(request, case):
 
 def test_tag_filter(testdir):
     # When `tag` is specified
-    parameters = {"parameters": [integer(name="id", required=True)]}
+    parameters = {"parameters": [integer(name="id", required=True)], "responses": {"200": {"description": "OK"}}}
     testdir.make_test(
         """
 @schema.parametrize(tag="bar")
@@ -67,7 +67,7 @@ def test_(request, case):
             "/foo": {"get": {**parameters, "tags": ["foo", "baz"]}},
             "/bar": {"get": {**parameters, "tags": ["bar", "baz"]}},
         },
-        tags={"foo": {}, "bar": {}, "baz": {}},
+        tags=[{"name": "foo"}, {"name": "bar"}, {"name": "baz"}],
     )
     result = testdir.runpytest("-v", "-s")
     result.assert_outcomes(passed=1)
@@ -86,8 +86,14 @@ def test_(request, case):
     assert case.method == "POST"
 """,
         paths={
-            "/foo": {"post": {"parameters": []}, "get": {"parameters": []}},
-            "/bar": {"post": {"parameters": []}, "get": {"parameters": []}},
+            "/foo": {
+                "post": {"parameters": [], "responses": {"200": {"description": "OK"}}},
+                "get": {"parameters": [], "responses": {"200": {"description": "OK"}}},
+            },
+            "/bar": {
+                "post": {"parameters": [], "responses": {"200": {"description": "OK"}}},
+                "get": {"parameters": [], "responses": {"200": {"description": "OK"}}},
+            },
         },
         method="POST",
         endpoint="/v1/foo",
@@ -114,7 +120,15 @@ def test_b(request, case):
     assert case.path == "/v1/foo"
     assert case.method == "POST"
 """,
-        paths={"/foo": {"post": {"parameters": [integer(name="id", required=True)], "tags": ["foo"]}}},
+        paths={
+            "/foo": {
+                "post": {
+                    "parameters": [integer(name="id", required=True)],
+                    "responses": {"200": {"description": "OK"}},
+                    "tags": ["foo"],
+                }
+            }
+        },
         method="POST",
         endpoint="/v1/foo",
         tag="foo",

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -59,8 +59,18 @@ def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
 """,
         paths={
-            "/valid": {"get": {"parameters": [{"type": "integer", "name": "id", "in": "query", "required": True}]}},
-            "/invalid": {"get": {"parameters": [{"type": "int", "name": "id", "in": "query", "required": True}]}},
+            "/valid": {
+                "get": {
+                    "parameters": [{"type": "integer", "name": "id", "in": "query", "required": True}],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            },
+            "/invalid": {
+                "get": {
+                    "parameters": [{"type": "int", "name": "id", "in": "query", "required": True}],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            },
         },
     )
     result = testdir.runpytest("-v", "-rf")
@@ -137,10 +147,16 @@ def test_c(request, case):
     assert case.method == "GET"
 """,
         paths={
-            "/first": {"post": {"tags": ["bar"]}, "get": {"tags": ["baz"]}},
-            "/second": {"post": {}, "get": {"tags": ["foo"]}},
+            "/first": {
+                "post": {"tags": ["bar"], "responses": {"200": {"description": "OK"}}},
+                "get": {"tags": ["baz"], "responses": {"200": {"description": "OK"}}},
+            },
+            "/second": {
+                "post": {"responses": {"200": {"description": "OK"}}},
+                "get": {"tags": ["foo"], "responses": {"200": {"description": "OK"}}},
+            },
         },
-        tags={"foo": {}, "bar": {}},
+        tags=[{"name": "foo"}, {"name": "bar"}],
     )
     result = testdir.runpytest("-v")
     # Then the filters should be applied to the generated tests
@@ -181,9 +197,18 @@ def test_c(request, case):
     request.config.HYPOTHESIS_CASES += 1
 """,
         paths={
-            "/first": {"post": {"tags": ["foo"]}, "get": {"tags": ["foo"]}},
-            "/second": {"post": {"tags": ["foo"]}, "get": {"tags": ["foo"]}},
-            "/third": {"post": {"tags": ["bar"]}, "get": {"tags": ["bar"]}},
+            "/first": {
+                "post": {"tags": ["foo"], "responses": {"200": {"description": "OK"}}},
+                "get": {"tags": ["foo"], "responses": {"200": {"description": "OK"}}},
+            },
+            "/second": {
+                "post": {"tags": ["foo"], "responses": {"200": {"description": "OK"}}},
+                "get": {"tags": ["foo"], "responses": {"200": {"description": "OK"}}},
+            },
+            "/third": {
+                "post": {"tags": ["bar"], "responses": {"200": {"description": "OK"}}},
+                "get": {"tags": ["bar"], "responses": {"200": {"description": "OK"}}},
+            },
         },
         method="POST",
         endpoint="/first",
@@ -222,7 +247,7 @@ def test_a(request, case):
     assert case.path == "/v1/pets"
     assert case.method == "POST"
 """,
-        paths={"/pets": {"post": {}}},
+        paths={"/pets": {"post": {"responses": {"200": {"description": "OK"}}}}},
     )
     result = testdir.runpytest("-v")
     # Then the filters should be applied to the generated tests
@@ -251,7 +276,16 @@ def test_b(request, case):
     request.config.HYPOTHESIS_CASES += 1
     assert case.path == "/v1/second"
 """,
-        paths={"/first": {"post": {}, "get": {}}, "/second": {"post": {}, "get": {}}},
+        paths={
+            "/first": {
+                "post": {"responses": {"200": {"description": "OK"}}},
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+            "/second": {
+                "post": {"responses": {"200": {"description": "OK"}}},
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+        },
         method="GET",
         endpoint="/first",
     )
@@ -303,7 +337,16 @@ def test_d(request, case):
     assert case.method == "POST"
 
 """,
-        paths={"/first": {"post": {}, "get": {}}, "/second": {"post": {}, "get": {}}},
+        paths={
+            "/first": {
+                "post": {"responses": {"200": {"description": "OK"}}},
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+            "/second": {
+                "post": {"responses": {"200": {"description": "OK"}}},
+                "get": {"responses": {"200": {"description": "OK"}}},
+            },
+        },
     )
     result = testdir.runpytest("-v")
     # Then the filters should be applied to the generated tests

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -50,7 +50,10 @@ def test_(case):
         """,
         paths={
             "/users": {
-                "post": {"parameters": [{"name": "id", "in": "body", "required": True, "schema": {"type": "integer"}}]}
+                "post": {
+                    "parameters": [{"name": "id", "in": "body", "required": True, "schema": {"type": "integer"}}],
+                    "responses": {"200": {"description": "OK"}},
+                }
             }
         },
     )
@@ -69,7 +72,10 @@ def test_(case):
         """,
         paths={
             "/users/{user_id}": {
-                "get": {"parameters": [{"name": "user_id", "required": True, "in": "path", "type": "integer"}]}
+                "get": {
+                    "parameters": [{"name": "user_id", "required": True, "in": "path", "type": "integer"}],
+                    "responses": {"200": {"description": "OK"}},
+                }
             }
         },
     )

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -136,6 +136,7 @@ def test_date_deserializing(testdir):
                             },
                         }
                     ],
+                    "responses": {"200": {"description": "OK"}},
                 }
             }
         },

--- a/test/test_parametrization.py
+++ b/test/test_parametrization.py
@@ -1,4 +1,4 @@
-from .utils import integer, string
+from .utils import integer
 
 
 def test_parametrization(testdir):
@@ -32,7 +32,12 @@ def test_(request, param, case):
     assert case.path == "/v1/users"
     assert case.method in ("GET", "POST")
 """,
-        paths={"/users": {"get": {}, "post": {}}},
+        paths={
+            "/users": {
+                "get": {"responses": {"200": {"description": "OK"}}},
+                "post": {"responses": {"200": {"description": "OK"}}},
+            }
+        },
     )
     # And there are multiple method/endpoint combinations
     result = testdir.runpytest("-v", "-s")
@@ -59,7 +64,12 @@ class TestAPI:
         assert case.path == "/v1/users"
         assert case.method in ("GET", "POST")
 """,
-        paths={"/users": {"get": {}, "post": {}}},
+        paths={
+            "/users": {
+                "get": {"responses": {"200": {"description": "OK"}}},
+                "post": {"responses": {"200": {"description": "OK"}}},
+            }
+        },
     )
     # Then they should work as regular tests
     result = testdir.runpytest("-v", "-s")
@@ -75,7 +85,7 @@ class TestAPI:
 
 def test_max_examples(testdir):
     # When `max_examples` is specified
-    parameters = {"parameters": [integer(name="id", required=True)]}
+    parameters = {"parameters": [integer(name="id", required=True)], "responses": {"200": {"description": "OK"}}}
     testdir.make_test(
         """
 @schema.parametrize()
@@ -116,7 +126,8 @@ def test_(request, case):
                             "name": "object",
                             "required": True,
                         }
-                    ]
+                    ],
+                    "responses": {"200": {"description": "OK"}},
                 }
             }
         },
@@ -149,7 +160,8 @@ def test(request, case):
                             "name": "object",
                             "required": True,
                         }
-                    ]
+                    ],
+                    "responses": {"200": {"description": "OK"}},
                 }
             }
         },
@@ -183,7 +195,7 @@ def test_a(request, case):
 def test_b(request, case):
     request.config.HYPOTHESIS_CASES += 1
     """,
-        paths={"/pets": {"post": {}}},
+        paths={"/pets": {"post": {"responses": {"200": {"description": "OK"}}}}},
     )
     result = testdir.runpytest("-v", "-s", "-k", "pets")
     # Then only relevant tests should be selected for running
@@ -219,7 +231,22 @@ def test_exception_during_test(testdir):
 def test_(request, case):
     pass
 """,
-        paths={"/users": {"get": {"parameters": [string(name="key5", minLength=10, maxLength=6, required=True)]}}},
+        paths={
+            "/users": {
+                "get": {
+                    "parameters": [
+                        {
+                            "type": "string",
+                            "in": "query",
+                            "name": "key5",
+                            "minLength": 10,
+                            "maxLength": 6,
+                            "required": True,
+                        }
+                    ]
+                }
+            }
+        },
     )
     result = testdir.runpytest("-v", "-rf")
     # Then the tests should fail with the relevant error message

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -15,7 +15,12 @@ def test_(request, param, case):
     assert case.path == "/v1/users"
     assert case.method in ("GET", "POST")
 """,
-        paths={"/users": {"get": {}, "post": {}}},
+        paths={
+            "/users": {
+                "get": {"responses": {"200": {"description": "OK"}}},
+                "post": {"responses": {"200": {"description": "OK"}}},
+            }
+        },
     )
     # And there are multiple method/endpoint combinations
     result = testdir.runpytest("-v", "-s")
@@ -52,7 +57,12 @@ class TestAPI:
         assert case.path == "/v1/users"
         assert case.method in ("GET", "POST")
 """,
-        paths={"/users": {"get": {}, "post": {}}},
+        paths={
+            "/users": {
+                "get": {"responses": {"200": {"description": "OK"}}},
+                "post": {"responses": {"200": {"description": "OK"}}},
+            }
+        },
     )
     # And there are multiple method/endpoint combinations
     result = testdir.runpytest("-v", "-s")

--- a/test/test_required.py
+++ b/test/test_required.py
@@ -1,4 +1,4 @@
-from .utils import as_param, integer
+from .utils import as_param
 
 
 def test_required_parameters(testdir):
@@ -20,9 +20,10 @@ def test_(request, case):
                             "in": "body",
                             "name": "object",
                             "required": True,
-                            "schema": {"type": "object", "required": ["id"], "properties": {"id": integer(name="id")}},
+                            "schema": {"type": "object", "required": ["id"], "properties": {"id": {"type": "integer"}}},
                         }
-                    ]
+                    ],
+                    "responses": {"200": {"description": "OK"}},
                 }
             }
         },

--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -40,9 +40,10 @@ def test_cookies(flask_app):
                                 "name": "token",
                                 "in": "cookie",
                                 "required": True,
-                                "schema": {"type": "string", "const": "test"},
+                                "schema": {"type": "string", "enum": ["test"]},
                             }
-                        ]
+                        ],
+                        "responses": {"200": {"description": "OK"}},
                     }
                 }
             },
@@ -88,8 +89,24 @@ def test_not_wsgi(schema):
         case.call_wsgi()
 
 
-@pytest.mark.endpoints("upload_file")
-def test_binary_body(mocker, schema):
+def test_binary_body(mocker, flask_app):
+    schema = schemathesis.from_dict(
+        {
+            "openapi": "3.0.2",
+            "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+            "paths": {
+                "/api/upload_file": {
+                    "post": {
+                        "requestBody": {
+                            "content": {"application/octet-stream": {"schema": {"format": "binary", "type": "string"}}}
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        },
+        app=flask_app,
+    )
     strategy = schema.endpoints["/api/upload_file"]["POST"].as_strategy()
 
     @given(case=strategy)


### PR DESCRIPTION
Tests for `additionalItems` are removed since they are relevant to the JSONSchema, not to Open API