### PR TITLE
Fix Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN addgroup --gid 1000 -S schemathesis && \
     apk del .build-deps
 
 USER schemathesis
-CMD ["schemathesis", "--help"]
+ENTRYPOINT ["schemathesis"]


### PR DESCRIPTION
This PR fixes #361 . It also removes the `--help` because the current default behaviour of calling `schemathesis` with no args is to show help.

Testing the fix:

```sh
$ docker build .
Sending build context to Docker daemon  226.3kB
Step 1/7 : FROM python:3.8-alpine
...
Step 7/7 : ENTRYPOINT ["schemathesis"]
 ---> Running in 8f3cbb7d2064
Removing intermediate container 8f3cbb7d2064
 ---> 01612928cbf0
Successfully built 01612928cbf0
```

Call with no args shows help:

```sh
$ docker run 01612928cbf0
Usage: schemathesis [OPTIONS] COMMAND [ARGS]...

  Command line tool for testing your web application built with Open API /
  Swagger specifications.

Options:
  --pre-run TEXT  A module to execute before the running the tests.
  --version       Show the version and exit.
  -h, --help      Show this message and exit.

Commands:
  run  Perform schemathesis test.
```

Asking for version works:

```sh
$ docker run 01612928cbf0 --version
schemathesis, version 0.23.0
```

Run works as per README:

```sh
$ docker run 01612928cbf0 run
Usage: schemathesis run [OPTIONS] SCHEMA
Try "schemathesis run -h" for help.

Error: Missing argument "SCHEMA".
$ docker run 01612928cbf0 run http://example.com/schema.yml
Aborted!
Schema was not found at http://example.com/schema.yml
```