### PR TITLE
fix: Generation of invalid values in `Case.cookies`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Generation of invalid values in ``Case.cookies``. `#371`_
+
 `0.23.4`_ - 2020-01-22
 ----------------------
 
@@ -619,6 +624,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#371: https://github.com/kiwicom/schemathesis/issues/371
 .. _#367: https://github.com/kiwicom/schemathesis/issues/367
 .. _#365: https://github.com/kiwicom/schemathesis/issues/365
 .. _#361: https://github.com/kiwicom/schemathesis/issues/361

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -154,7 +154,7 @@ def get_case_strategy(endpoint: Endpoint) -> st.SearchStrategy:
                     strategies[parameter] = (
                         from_schema(value).filter(filter_path_parameters).map(quote_all)  # type: ignore
                     )
-                elif parameter == "headers":
+                elif parameter in ("headers", "cookies"):
                     strategies[parameter] = from_schema(value).filter(is_valid_header)  # type: ignore
                 elif parameter == "query":
                     strategies[parameter] = from_schema(value).filter(is_valid_query)  # type: ignore

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -13,9 +13,9 @@ def test_headers(testdir):
     testdir.make_test(
         """
 @schema.parametrize()
-@settings(max_examples=1)
 def test_(case):
     assert_str(case.headers["api_key"])
+    assert_requests_call(case)
         """,
         **as_param({"name": "api_key", "in": "header", "required": True, "type": "string"}),
     )
@@ -28,9 +28,9 @@ def test_cookies(testdir):
     testdir.make_test(
         """
 @schema.parametrize()
-@settings(max_examples=1)
 def test_(case):
     assert_str(case.cookies["token"])
+    assert_requests_call(case)
         """,
         schema_name="simple_openapi.yaml",
         **as_param({"name": "token", "in": "cookie", "required": True, "schema": {"type": "string"}}),
@@ -47,6 +47,7 @@ def test_body(testdir):
 @settings(max_examples=3)
 def test_(case):
     assert_int(case.body)
+    assert_requests_call(case)
         """,
         paths={
             "/users": {
@@ -69,6 +70,7 @@ def test_path(testdir):
 @settings(max_examples=3)
 def test_(case):
     assert_int(case.path_parameters["user_id"])
+    assert_requests_call(case)
         """,
         paths={
             "/users/{user_id}": {
@@ -91,6 +93,7 @@ def test_form_data(testdir):
 @settings(max_examples=1)
 def test_(case):
     assert_str(case.form_data["status"])
+    assert_requests_call(case)
         """,
         **as_param({"name": "status", "in": "formData", "required": True, "type": "string"}),
     )


### PR DESCRIPTION
Fixes #371 