### PR TITLE
fix: Handling examples of parameters in Open API 3.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ Added
 
 - ``-x``/``--exitfirst`` CLI option to exit after first failed test. `#378`_
 
+Fixed
+~~~~~
+
+- Handling examples of parameters in Open API 3.0. `#381`_
+
 `0.23.6`_ - 2020-01-28
 ----------------------
 
@@ -647,6 +652,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#381: https://github.com/kiwicom/schemathesis/issues/381
 .. _#378: https://github.com/kiwicom/schemathesis/issues/378
 .. _#376: https://github.com/kiwicom/schemathesis/issues/376
 .. _#374: https://github.com/kiwicom/schemathesis/issues/374

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -315,6 +315,12 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
         else:
             super().process_by_type(endpoint, parameter)
 
+    def add_parameter(self, container: Optional[Dict[str, Any]], parameter: Dict[str, Any]) -> Dict[str, Any]:
+        container = super().add_parameter(container, parameter)
+        if "example" in parameter:
+            container["example"] = {parameter["name"]: parameter["example"]}
+        return container
+
     def process_cookie(self, endpoint: Endpoint, parameter: Dict[str, Any]) -> None:
         endpoint.cookies = self.add_parameter(endpoint.cookies, parameter)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -127,9 +127,10 @@ def testdir(testdir):
         tag=None,
         pytest_plugins=("aiohttp.pytest_plugin",),
         validate_schema=True,
+        schema=None,
         **kwargs,
     ):
-        schema = make_schema(**kwargs)
+        schema = schema or make_schema(**kwargs)
         preparation = dedent(
             """
         import pytest


### PR DESCRIPTION
Fixes #381 