### PR TITLE
feat: `--show-error-tracebacks` CLI option to display errors' tracebacks in the output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Added
 ~~~~~
 
 - Support for testing of examples in Parameter & Media Type objects in Open API 3.0. `#394`_
+- ``--show-error-tracebacks`` CLI option to display errors' tracebacks in the output. `#391`_
 
 Changed
 ~~~~~~~
@@ -673,6 +674,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#394: https://github.com/kiwicom/schemathesis/issues/394
+.. _#391: https://github.com/kiwicom/schemathesis/issues/391
 .. _#386: https://github.com/kiwicom/schemathesis/issues/386
 .. _#383: https://github.com/kiwicom/schemathesis/issues/383
 .. _#381: https://github.com/kiwicom/schemathesis/issues/381

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -16,6 +16,7 @@ class ExecutionContext:
 
     hypothesis_output: List[str] = attr.ib(factory=list)  # pragma: no mutate
     workers_num: int = attr.ib(default=1)  # pragma: no mutate
+    show_errors_tracebacks: bool = attr.ib(default=False)  # pragma: no mutate
     endpoints_processed: int = attr.ib(default=0)  # pragma: no mutate
     current_line_length: int = attr.ib(default=0)  # pragma: no mutate
     terminal_size: os.terminal_size = attr.ib(factory=shutil.get_terminal_size)  # pragma: no mutate

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -94,7 +94,9 @@ def capture_hypothesis_output() -> Generator[List[str], None, None]:
         yield output
 
 
-def format_exception(error: Exception) -> str:
+def format_exception(error: Exception, include_traceback: bool = False) -> str:
+    if include_traceback:
+        return "".join(traceback.format_exception(type(error), error, error.__traceback__))
     return "".join(traceback.format_exception_only(type(error), error))
 
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -135,6 +135,7 @@ def test_commands_run_help(cli):
         "  --request-timeout INTEGER       Timeout in milliseconds for network requests",
         "                                  during the test run.",
         "  --validate-schema BOOLEAN       Enable or disable validation of input schema.",
+        "  --show-errors-tracebacks        Show full tracebacks for internal errors.",
         "  --hypothesis-deadline INTEGER   Duration in milliseconds that each individual",
         "                                  example with a test is not allowed to exceed.",
         "  --hypothesis-derandomize        Use Hypothesis's deterministic mode.",


### PR DESCRIPTION
Resolves #391 