### PR TITLE
Fixing path check in cli

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- CLI crash on Windows and Python < 3.8 when the schema path contains characters unrepresentable at the OS level. `#400`_
+
 `0.24.0`_ - 2020-02-07
 ----------------------
 
@@ -678,6 +683,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#400: https://github.com/kiwicom/schemathesis/issues/400
 .. _#394: https://github.com/kiwicom/schemathesis/issues/394
 .. _#391: https://github.com/kiwicom/schemathesis/issues/391
 .. _#386: https://github.com/kiwicom/schemathesis/issues/386

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -1,4 +1,3 @@
-import pathlib
 import traceback
 from contextlib import contextmanager
 from enum import Enum
@@ -193,7 +192,7 @@ def run(  # pylint: disable=too-many-arguments
 
     with abort_on_network_errors():
         options.update({"checks": selected_checks, "workers_num": workers_num})
-        if pathlib.Path(schema).is_file():
+        if utils.file_exists(schema):
             options["loader"] = from_path
         elif app is not None and not urlparse(schema).netloc:
             # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with

--- a/src/schemathesis/cli/callbacks.py
+++ b/src/schemathesis/cli/callbacks.py
@@ -1,4 +1,3 @@
-import pathlib
 import re
 import sys
 from contextlib import contextmanager
@@ -13,19 +12,11 @@ from .. import utils
 
 def validate_schema(ctx: click.core.Context, param: click.core.Parameter, raw_value: str) -> str:
     if "app" not in ctx.params and not urlparse(raw_value).netloc:
-        if "\x00" in raw_value or not _verify_path(raw_value):
+        if "\x00" in raw_value or not utils.file_exists(raw_value):
             raise click.UsageError("Invalid SCHEMA, must be a valid URL or file path.")
         if "base_url" not in ctx.params:
             raise click.UsageError('Missing argument, "--base-url" is required for SCHEMA specified by file.')
     return raw_value
-
-
-def _verify_path(path: str) -> bool:
-    try:
-        return pathlib.Path(path).is_file()
-    except OSError:
-        # For example, path could be too long
-        return False
 
 
 def validate_base_url(ctx: click.core.Context, param: click.core.Parameter, raw_value: str) -> str:

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,4 +1,5 @@
 import cgi
+import pathlib
 import traceback
 import warnings
 from contextlib import contextmanager
@@ -14,6 +15,14 @@ from werkzeug.wrappers.json import JSONMixin
 from .types import Filter, NotSet
 
 NOT_SET = NotSet()
+
+
+def file_exists(path: str) -> bool:
+    try:
+        return pathlib.Path(path).is_file()
+    except OSError:
+        # For example, path could be too long
+        return False
 
 
 def deprecated(func: Callable, message: str) -> Callable:


### PR DESCRIPTION
This is a fix for #399 which worked for me.

os.path is not as cool as pathlib, but in this case it has the better behaviour. Namely it doesn't throw an error on Python < 3.8