### PR TITLE
fix: Resolving references when schema is loaded from a file on Windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Resolving references when schema is loaded from a file on Windows. `#418`_
+
 `0.24.3`_ - 2020-02-10
 ----------------------
 
@@ -712,6 +717,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#418: https://github.com/kiwicom/schemathesis/issues/418
 .. _#416: https://github.com/kiwicom/schemathesis/issues/416
 .. _#412: https://github.com/kiwicom/schemathesis/issues/412
 .. _#410: https://github.com/kiwicom/schemathesis/issues/410

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-arguments
-import os
+import pathlib
 from typing import IO, Any, Callable, Dict, Optional, Union
 from urllib.parse import urljoin
 
@@ -32,7 +32,7 @@ def from_path(
     with open(path) as fd:
         return from_file(
             fd,
-            location=os.path.abspath(path),
+            location=pathlib.Path(path).absolute().as_uri(),
             base_url=base_url,
             method=method,
             endpoint=endpoint,

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1,7 +1,7 @@
-import os
-import platform
+import pathlib
 import time
 from test.utils import HERE, SIMPLE_PATH
+from urllib.parse import urljoin
 
 import pytest
 import yaml
@@ -883,9 +883,9 @@ def test_hypothesis_output_capture(mocker, cli, cli_args, workers):
     assert "Falsifying example" in result.stdout
 
 
-@pytest.mark.xfail(platform.system() == "Windows", reason="Resolving is currently not supported on Windows.")
 async def test_multiple_files_schema(app, testdir, cli, base_url):
     # When the schema contains references to other files
+    uri = pathlib.Path(HERE).as_uri() + "/"
     schema = {
         "swagger": "2.0",
         "info": {"title": "Example API", "description": "An API to test Schemathesis", "version": "1.0.0"},
@@ -899,8 +899,8 @@ async def test_multiple_files_schema(app, testdir, cli, base_url):
                     "parameters": [
                         {
                             # during the CLI run we have a different working directory,
-                            # so specifying an absolute file path
-                            "schema": {"$ref": os.path.join(HERE, "data/petstore_v2.yaml#/definitions/Pet")},
+                            # so specifying an absolute uri
+                            "schema": {"$ref": urljoin(uri, "data/petstore_v2.yaml#/definitions/Pet")},
                             "in": "body",
                             "name": "user",
                             "required": True,

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -1,5 +1,3 @@
-import platform
-
 import pytest
 import yaml
 
@@ -486,7 +484,6 @@ COMMON_RESPONSES = {
 }
 
 
-@pytest.mark.xfail(platform.system() == "Windows", reason="Resolving is currently not supported on Windows.")
 def test_complex_dereference(testdir):
     # This tests includes:
     #   - references to other files


### PR DESCRIPTION
Fixes #418 

With `file://` schema things are much simpler