### PR TITLE
fix: Error during `pytest` collection on objects that have custom `__getattr__` method and therefore pass `is_schemathesis` check

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Error during ``pytest`` collection on objects that have custom ``__getattr__`` method and therefore pass ``is_schemathesis`` check. `#429`_
+
 `0.24.4`_ - 2020-02-22
 ----------------------
 
@@ -721,6 +726,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#429: https://github.com/kiwicom/schemathesis/issues/429
 .. _#418: https://github.com/kiwicom/schemathesis/issues/418
 .. _#416: https://github.com/kiwicom/schemathesis/issues/416
 .. _#412: https://github.com/kiwicom/schemathesis/issues/412

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -63,7 +63,11 @@ def deprecated(func: Callable, message: str) -> Callable:
 def is_schemathesis_test(func: Callable) -> bool:
     """Check whether test is parametrized with schemathesis."""
     try:
-        return hasattr(func, "_schemathesis_test")
+        from .schemas import BaseSchema  # pylint: disable=import-outside-toplevel
+
+        item = getattr(func, "_schemathesis_test", None)
+        # Comparison is needed to avoid false-positives when mocks are collected by pytest
+        return isinstance(item, BaseSchema)
     except Exception:
         return False
 

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -78,3 +78,19 @@ class TestAPI:
             r"Hypothesis calls: 4",
         ]
     )
+
+
+def test_pytest_collection_regression(testdir):
+    # See #429.
+    # When in a module scope there is an object that has custom `__getattr__` (a mock for example)
+    testdir.make_test(
+        """
+from unittest.mock import call
+
+def test_schemathesis():
+    assert True
+""",
+    )
+    result = testdir.runpytest()
+    # It shouldn't be collected as a test
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fixes #429 