### PR TITLE
fix: Typo in a help message in the CLI output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Typo in a help message in the CLI output. `#436`_
+
 `0.25.1`_ - 2020-03-09
 ----------------------
 
@@ -748,6 +753,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#436: https://github.com/kiwicom/schemathesis/issues/436
 .. _#433: https://github.com/kiwicom/schemathesis/issues/433
 .. _#429: https://github.com/kiwicom/schemathesis/issues/429
 .. _#424: https://github.com/kiwicom/schemathesis/issues/424

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -114,7 +114,7 @@ def display_errors(context: events.ExecutionContext, results: TestResultSet) -> 
         display_single_error(context, result)
     if not context.show_errors_tracebacks:
         click.secho(
-            "Add this option to your command line parameters to see full tracebacks: --show-error-tracebacks", fg="red"
+            "Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks", fg="red"
         )
 
 

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -279,7 +279,7 @@ def test_display_errors(swagger_20, capsys, results_set, execution_context, show
     # Then section title is displayed
     assert " ERRORS " in out
     help_message_exists = (
-        "Add this option to your command line parameters to " "see full tracebacks: --show-error-tracebacks" in out
+        "Add this option to your command line parameters to see full tracebacks: --show-errors-tracebacks" in out
     )
     # And help message is displayed only if tracebacks are not shown
     assert help_message_exists is not show_errors_tracebacks


### PR DESCRIPTION
Closes #436 