### PR TITLE
Fixes bug where an empty string would be accepted as a required path template variable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 Fixed
 ~~~~~
 
+- Filter invalid empty `""` path template variables. `#439`_
 - Typo in a help message in the CLI output. `#436`_
 
 `0.25.1`_ - 2020-03-09

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -147,12 +147,18 @@ def get_case_strategy(endpoint: Endpoint) -> st.SearchStrategy:
 
 
 def filter_path_parameters(parameters: Dict[str, Any]) -> bool:
-    """Single "." chars are excluded from path by urllib3.
+    """Single "." chars and empty strings "" are excluded from path by urllib3.
 
     In this case one variable in the path template will be empty, which will lead to 404 in most of the cases.
     Because of it this case doesn't bring much value and might lead to false positives results of Schemathesis runs.
     """
-    return not any(value == "." for value in parameters.values())
+
+    path_parameter_blacklist = (
+        ".",
+        "",
+    )
+
+    return not any(value in path_parameter_blacklist for value in parameters.values())
 
 
 def quote_all(parameters: Dict[str, Any]) -> Dict[str, Any]:

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -309,9 +309,10 @@ def test_response_conformance_malformed_json(args):
 @pytest.fixture()
 def filter_path_parameters():
     # ".." and "." strings are treated specially, but this behavior is outside of the test's scope
+    # "" shouldn't be allowed as a valid path parameter
 
     def schema_filter(strategy):
-        return strategy.filter(lambda x: x["key"] not in ("..", "."))
+        return strategy.filter(lambda x: x["key"] not in ("..", ".", ""))
 
     schemathesis.hooks.register("path_parameters", schema_filter)
     yield


### PR DESCRIPTION
As discussed on gitter there's currently a bug where schemathesis will allow `""` as a valid input for a required path variable. This behaviour is incorrect and fixed with this patch. 