### PR TITLE
fix: Filter problematic strings with slashes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 Fixed
 ~~~~~
 
+- Filter problematic path template variables containing `"/"`, or `"%2F"` url encoded. `#440`_
 - Filter invalid empty `""` path template variables. `#439`_
 - Typo in a help message in the CLI output. `#436`_
 

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -18,6 +18,7 @@ from .models import Case, Endpoint
 from .types import Hook
 
 PARAMETERS = frozenset(("path_parameters", "headers", "cookies", "query", "body", "form_data"))
+SLASH = "/"
 
 
 def create_test(
@@ -159,12 +160,12 @@ def filter_path_parameters(parameters: Dict[str, Any]) -> bool:
 
     path_parameter_blacklist = (
         ".",
-        "/",
+        SLASH,
         "",
     )
 
     return not any(
-        (value in path_parameter_blacklist or isinstance(value, str) and path_parameter_blacklist[1] in value)
+        (value in path_parameter_blacklist or isinstance(value, str) and SLASH in value)
         for value in parameters.values()
     )
 

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -164,11 +164,7 @@ def filter_path_parameters(parameters: Dict[str, Any]) -> bool:
     )
 
     return not any(
-        (
-            value in path_parameter_blacklist
-            or isinstance(value, str)
-            and path_parameter_blacklist[1] in value
-        )
+        (value in path_parameter_blacklist or isinstance(value, str) and path_parameter_blacklist[1] in value)
         for value in parameters.values()
     )
 

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -313,8 +313,7 @@ def filter_path_parameters():
 
     def schema_filter(strategy):
         return strategy.filter(
-            lambda x: x["key"] not in ("..", ".", "", "/")
-            and not (isinstance(x["key"], str) and "/" in x["key"])
+            lambda x: x["key"] not in ("..", ".", "", "/") and not (isinstance(x["key"], str) and "/" in x["key"])
         )
 
     schemathesis.hooks.register("path_parameters", schema_filter)

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -312,7 +312,10 @@ def filter_path_parameters():
     # "" shouldn't be allowed as a valid path parameter
 
     def schema_filter(strategy):
-        return strategy.filter(lambda x: x["key"] not in ("..", ".", ""))
+        return strategy.filter(
+            lambda x: x["key"] not in ("..", ".", "", "/")
+            and not (isinstance(x["key"], str) and "/" in x["key"])
+        )
 
     schemathesis.hooks.register("path_parameters", schema_filter)
     yield
@@ -322,7 +325,7 @@ def filter_path_parameters():
 @pytest.mark.endpoints("path_variable")
 @pytest.mark.usefixtures("filter_path_parameters")
 def test_path_parameters_encoding(schema_url):
-    # NOTE. Flask still decodes %2F as / and returns 404
+    # NOTE. WSGI and ASGI applications decodes %2F as / and returns 404
     # When endpoint has a path parameter
     results = execute(schema_url, checks=(status_code_conformance,), hypothesis_options={"derandomize": True})
     # Then there should be no failures


### PR DESCRIPTION
Filters problematic strings containing slashes or htmlencoded `%2F`.

These strings causes problems both in WSGI and ASGI based applications.

Follow up on https://github.com/kiwicom/schemathesis/pull/439 

Related issue: https://github.com/tiangolo/fastapi/issues/1132