### PR TITLE
chore: Remove deprecated `Parametrizer` class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Removed
+~~~~~~~
+
+- Deprecated ``Parametrizer`` class. Use ``schemathesis.from_path`` as a replacement for ``Parametrizer.from_path``.
+
 `0.26.1`_ - 2020-03-24
 ----------------------
 

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -2,7 +2,7 @@ from . import hooks
 from ._hypothesis import init_default_strategies, register_string_format
 from .cli import register_check
 from .constants import __version__
-from .loaders import Parametrizer, from_dict, from_file, from_path, from_pytest_fixture, from_uri, from_wsgi
+from .loaders import from_dict, from_file, from_path, from_pytest_fixture, from_uri, from_wsgi
 from .models import Case
 
 init_default_strategies()

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -15,7 +15,7 @@ from .exceptions import HTTPError
 from .lazy import LazySchema
 from .schemas import BaseSchema, OpenApi30, SwaggerV20
 from .types import Filter, PathLike
-from .utils import NOT_SET, StringDatesYAMLLoader, WSGIResponse, deprecated, get_base_url
+from .utils import NOT_SET, StringDatesYAMLLoader, WSGIResponse, get_base_url
 
 
 def from_path(
@@ -211,9 +211,3 @@ def from_aiohttp(
     if not base_url:
         base_url = app_url
     return from_uri(url, base_url=base_url, method=method, endpoint=endpoint, tag=tag, validate_schema=validate_schema)
-
-
-# Backward compatibility
-class Parametrizer:
-    from_path = deprecated(from_path, "`Parametrizer.from_path` is deprecated, use `schemathesis.from_path` instead.")
-    from_uri = deprecated(from_uri, "`Parametrizer.from_uri` is deprecated, use `schemathesis.from_uri` instead.")

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -2,9 +2,7 @@ import cgi
 import pathlib
 import re
 import traceback
-import warnings
 from contextlib import contextmanager
-from functools import wraps
 from typing import Any, Callable, Dict, Generator, List, Set, Tuple, Type, Union
 from urllib.parse import urlsplit, urlunsplit
 
@@ -47,17 +45,6 @@ def has_invalid_characters(name: str, value: str) -> bool:
         return bool(INVALID_HEADER_RE.search(value))
     except InvalidHeader:
         return True
-
-
-def deprecated(func: Callable, message: str) -> Callable:
-    """Emit a warning if the given function is used."""
-
-    @wraps(func)  # pragma: no mutate
-    def inner(*args: Any, **kwargs: Any) -> Any:
-        warnings.warn(message, DeprecationWarning)
-        return func(*args, **kwargs)
-
-    return inner
 
 
 def is_schemathesis_test(func: Callable) -> bool:

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -36,20 +36,6 @@ def test_base_url_override(schema_url, url):
     assert endpoint.base_url == "http://example.com"
 
 
-def test_backward_compatibility_path_loader(simple_schema):
-    # The deprecated loaders should emit deprecation warnings
-    message = r"^`Parametrizer.from_path` is deprecated, use `schemathesis.from_path` instead.\Z"
-    with pytest.warns(DeprecationWarning, match=message):
-        assert schemathesis.Parametrizer.from_path(SIMPLE_PATH).raw_schema == simple_schema
-
-
-def test_backward_compatibility_uri_loader(schema_url, app_schema):
-    # The deprecated loaders should emit deprecation warnings
-    message = r"^`Parametrizer.from_uri` is deprecated, use `schemathesis.from_uri` instead.\Z"
-    with pytest.warns(DeprecationWarning, match=message):
-        assert schemathesis.Parametrizer.from_uri(schema_url).raw_schema == app_schema
-
-
 def test_unsupported_type():
     with pytest.raises(ValueError, match="^Unsupported schema type$"):
         schemathesis.from_dict({})


### PR DESCRIPTION
It was deprecated for quite a while already. It is a part of clean-ups before 1.0 release