### PR TITLE
chore: Deprecate `runner.execute`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,7 +344,7 @@ For convenience you can explore the schemas and strategies manually:
         form_data={}
     )
 
-Schema instances implement `Mapping` protocol.
+Schema instances implement ``Mapping`` protocol.
 
 If you want to customize how data is generated, then you can use hooks of two types:
 
@@ -415,7 +415,16 @@ It can run tests against the given schema URI and will do some simple checks for
 
     from schemathesis import runner
 
-    runner.execute("http://127.0.0.1:8080/swagger.json")
+    events = runner.prepare("http://127.0.0.1:8080/swagger.json")
+    for event in events:
+        # do something with event
+
+``runner.prepare`` creates a generator that yields events of different kinds - ``BeforeExecution``, ``AfterExecution``, etc.
+They provide a lot of useful information about what happens during tests, but handling of these events is your responsibility.
+You can take some inspiration from Schemathesis `CLI implementation <https://github.com/kiwicom/schemathesis/blob/master/src/schemathesis/cli/__init__.py#L230>`_.
+See full description of events in the source code `here <https://github.com/kiwicom/schemathesis/blob/master/src/schemathesis/runner/events.py>`_.
+
+If you want to use Schemathesis CLI with your custom checks, look at `this section <https://github.com/kiwicom/schemathesis/tree/dd/deprecate-execute#registering-custom-checks-for-cli>`_
 
 The built-in checks list includes the following:
 
@@ -434,7 +443,9 @@ You can provide your custom checks to the execute function, the check is a calla
     def not_too_long(response, case: models.Case):
         assert response.elapsed < timedelta(milliseconds=300)
 
-    runner.execute("http://127.0.0.1:8080/swagger.json", checks=[not_too_long])
+    events = runner.prepare("http://127.0.0.1:8080/swagger.json", checks=[not_too_long])
+    for event in events:
+        # do something with event
 
 Custom string strategies
 ########################

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Deprecated
+~~~~~~~~~~
+
+- ``runner.execute`` should not be used, since ``runner.prepare`` provides a more flexible interface to test execution.
+
 Removed
 ~~~~~~~
 

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -2,6 +2,7 @@ import ctypes
 import logging
 import threading
 import time
+import warnings
 from contextlib import contextmanager
 from queue import Queue
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union, cast
@@ -416,6 +417,7 @@ def execute(  # pylint: disable=too-many-arguments
     hypothesis_options: Optional[Dict[str, Any]] = None,
     loader: Callable = from_uri,
 ) -> TestResultSet:
+    warnings.warn("`execute` is deprecated, use `prepare` instead.", DeprecationWarning)
     generator = prepare(
         schema_uri=schema_uri,
         checks=checks,

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -24,7 +24,11 @@ class ExecutionContext:
 
 @attr.s()  # pragma: no mutate
 class ExecutionEvent:
+    """Generic execution event."""
+
+    # Holder for all tests results in a particular run
     results: TestResultSet = attr.ib()  # pragma: no mutate
+    # Schema that is being tested
     schema: BaseSchema = attr.ib()  # pragma: no mutate
 
 
@@ -32,28 +36,47 @@ class ExecutionEvent:
 class Initialized(ExecutionEvent):
     """Runner is initialized, settings are prepared, requests session is ready."""
 
+    # List of checks that will be used during the run
     checks: Iterable[Callable] = attr.ib()  # pragma: no mutate
+    # Settings for `hypothesis` tests
     hypothesis_settings: hypothesis.settings = attr.ib()  # pragma: no mutate
+    # Timestamp of test run start
     start_time: float = attr.ib(factory=time.time)
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class BeforeExecution(ExecutionEvent):
+    """Happens before each examined endpoint.
+
+    It happens before a single hypothesis test, that may contain many examples inside.
+    """
+
+    # Endpoint being tested
     endpoint: Endpoint = attr.ib()  # pragma: no mutate
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class AfterExecution(ExecutionEvent):
+    """Happens after each examined endpoint."""
+
     endpoint: Endpoint = attr.ib()  # pragma: no mutate
+    # Endpoint test status - success / failure / error
     status: Status = attr.ib()  # pragma: no mutate
+    # Captured hypothesis stdout
     hypothesis_output: List[str] = attr.ib(factory=list)  # pragma: no mutate
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class Interrupted(ExecutionEvent):
-    pass
+    """If execution was interrupted by Ctrl-C or a received SIGTERM."""
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class Finished(ExecutionEvent):
+    """The final event of the run.
+
+    No more events after this point.
+    """
+
+    # Total test run execution time
     running_time: float = attr.ib()


### PR DESCRIPTION
It should not be used, since `runner.prepare` provides a more flexible interface to test execution.

Ref: #442 