### PR TITLE
refactor!: Remove deprecated `runner.execute`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Removed
+~~~~~~~
+
+- Deprecated ``runner.execute``. Use ``runner.prepare`` instead.
+
 `0.27.0`_ - 2020-03-31
 ----------------------
 

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -2,7 +2,6 @@ import ctypes
 import logging
 import threading
 import time
-import warnings
 from contextlib import contextmanager
 from queue import Queue
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union, cast
@@ -407,28 +406,6 @@ def run_test(
     yield events.AfterExecution(
         results=results, schema=schema, endpoint=endpoint, status=status, hypothesis_output=hypothesis_output
     )
-
-
-def execute(  # pylint: disable=too-many-arguments
-    schema_uri: str,
-    checks: Iterable[Check] = DEFAULT_CHECKS,
-    api_options: Optional[Dict[str, Any]] = None,
-    loader_options: Optional[Dict[str, Any]] = None,
-    hypothesis_options: Optional[Dict[str, Any]] = None,
-    loader: Callable = from_uri,
-) -> TestResultSet:
-    warnings.warn("`execute` is deprecated, use `prepare` instead.", DeprecationWarning)
-    generator = prepare(
-        schema_uri=schema_uri,
-        checks=checks,
-        api_options=api_options,
-        loader_options=loader_options,
-        hypothesis_options=hypothesis_options,
-        loader=loader,
-    )
-    all_events = list(generator)
-    finished = all_events[-1]
-    return finished.results
 
 
 def prepare(  # pylint: disable=too-many-arguments

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -8,12 +8,33 @@ from hypothesis import Phase
 from requests.auth import HTTPDigestAuth
 
 import schemathesis
-from schemathesis import from_wsgi
-from schemathesis.checks import content_type_conformance, response_schema_conformance, status_code_conformance
+from schemathesis import from_uri, from_wsgi
+from schemathesis.checks import (
+    DEFAULT_CHECKS,
+    content_type_conformance,
+    response_schema_conformance,
+    status_code_conformance,
+)
 from schemathesis.constants import __version__
 from schemathesis.exceptions import InvalidSchema
 from schemathesis.models import Status
-from schemathesis.runner import events, execute, get_base_url, get_requests_auth, get_wsgi_auth, prepare
+from schemathesis.runner import events, get_base_url, get_requests_auth, get_wsgi_auth, prepare
+
+
+def execute(
+    schema_uri, checks=DEFAULT_CHECKS, api_options=None, loader_options=None, hypothesis_options=None, loader=from_uri
+):
+    generator = prepare(
+        schema_uri=schema_uri,
+        checks=checks,
+        api_options=api_options,
+        loader_options=loader_options,
+        hypothesis_options=hypothesis_options,
+        loader=loader,
+    )
+    all_events = list(generator)
+    finished = all_events[-1]
+    return finished.results
 
 
 def assert_request(


### PR DESCRIPTION
Use `runner.prepare` instead