### PR TITLE
fix: Processing of explicit examples in Open API 3.0 when there are multiple parameters in the same location

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Processing of explicit examples in Open API 3.0 when there are multiple parameters in the same location (e.g. ``path``)
+  contain ``example`` value. They are properly combined now. `#450`_
+
 `1.0.0`_ - 2020-03-31
 ---------------------
 
@@ -809,6 +815,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#450: https://github.com/kiwicom/schemathesis/issues/450
 .. _#448: https://github.com/kiwicom/schemathesis/issues/448
 .. _#440: https://github.com/kiwicom/schemathesis/issues/440
 .. _#439: https://github.com/kiwicom/schemathesis/issues/439

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -363,12 +363,14 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
     def add_parameter(self, container: Optional[Dict[str, Any]], parameter: Dict[str, Any]) -> Dict[str, Any]:
         container = super().add_parameter(container, parameter)
         if "example" in parameter["schema"]:
-            container["example"] = {parameter["name"]: parameter["schema"]["example"]}
+            examples = container.setdefault("example", {})  # examples should be merged together
+            examples[parameter["name"]] = parameter["schema"]["example"]
         # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameter-object
         # > Furthermore, if referencing a schema which contains an example,
         # > the example value SHALL override the example provided by the schema
         if "example" in parameter:
-            container["example"] = {parameter["name"]: parameter["example"]}
+            examples = container.setdefault("example", {})  # examples should be merged together
+            examples[parameter["name"]] = parameter["example"]
         return container
 
     def process_cookie(self, endpoint: Endpoint, parameter: Dict[str, Any]) -> None:


### PR DESCRIPTION
Fixes #450 