### PR TITLE
refactor: Restructure runner

### DIFF
--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -14,7 +14,7 @@ from hypothesis.strategies import SearchStrategy
 from .checks import ALL_CHECKS
 from .exceptions import InvalidSchema
 from .types import Body, Cookies, FormData, Headers, PathParameters, Query
-from .utils import WSGIResponse
+from .utils import GenericResponse, WSGIResponse
 
 if TYPE_CHECKING:
     from .schemas import BaseSchema
@@ -331,3 +331,6 @@ class TestResultSet:
     def append(self, item: TestResult) -> None:
         """Add a new item to the results list."""
         self.results.append(item)
+
+
+CheckFunction = Callable[[GenericResponse, Case], None]  # pragma: no mutate

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -1,294 +1,93 @@
-import ctypes
-import logging
-import threading
-import time
-from contextlib import contextmanager
-from queue import Queue
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-import attr
-import hypothesis
 import hypothesis.errors
-import requests
-from _pytest.logging import LogCaptureHandler, catching_logs
-from requests.auth import HTTPDigestAuth, _basic_auth_str
 
 from .. import loaders
-from .._hypothesis import make_test_or_exception
 from ..checks import DEFAULT_CHECKS
-from ..constants import USER_AGENT
-from ..exceptions import InvalidSchema, get_grouped_exception
-from ..models import Case, Endpoint, Status, TestResult, TestResultSet
+from ..models import CheckFunction
 from ..schemas import BaseSchema
-from ..types import Filter, NotSet
-from ..utils import (
-    WSGIResponse,
-    capture_hypothesis_output,
-    dict_not_none_values,
-    dict_true_values,
-    file_exists,
-    get_base_url,
-)
+from ..types import Filter, NotSet, RawAuth
+from ..utils import dict_not_none_values, dict_true_values, file_exists, get_base_url, get_requests_auth
 from . import events
-
-DEFAULT_DEADLINE = 500  # pragma: no mutate
-RawAuth = Tuple[str, str]  # pragma: no mutate
-GenericResponse = Union[requests.Response, WSGIResponse]  # pragma: no mutate
-Check = Callable[[GenericResponse, Case], None]  # pragma: no mutate
+from .impl import BaseRunner, SingleThreadRunner, SingleThreadWSGIRunner, ThreadPoolRunner, ThreadPoolWSGIRunner
 
 
-def get_hypothesis_settings(hypothesis_options: Dict[str, Any]) -> hypothesis.settings:
-    # Default settings, used as a parent settings object below
-    hypothesis_options.setdefault("deadline", DEFAULT_DEADLINE)
-    return hypothesis.settings(**hypothesis_options)
+def prepare(  # pylint: disable=too-many-arguments
+    schema_uri: str,
+    *,
+    # Runtime behavior
+    checks: Iterable[CheckFunction] = DEFAULT_CHECKS,
+    workers_num: int = 1,
+    seed: Optional[int] = None,
+    exit_first: bool = False,
+    # Schema loading
+    loader: Callable = loaders.from_uri,
+    base_url: Optional[str] = None,
+    auth: Optional[Tuple[str, str]] = None,
+    auth_type: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    request_timeout: Optional[int] = None,
+    endpoint: Optional[Filter] = None,
+    method: Optional[Filter] = None,
+    tag: Optional[Filter] = None,
+    app: Any = None,
+    validate_schema: bool = True,
+    # Hypothesis-specific configuration
+    hypothesis_deadline: Optional[Union[int, NotSet]] = None,
+    hypothesis_derandomize: Optional[bool] = None,
+    hypothesis_max_examples: Optional[int] = None,
+    hypothesis_phases: Optional[List[hypothesis.Phase]] = None,
+    hypothesis_report_multiple_bugs: Optional[bool] = None,
+    hypothesis_suppress_health_check: Optional[List[hypothesis.HealthCheck]] = None,
+    hypothesis_verbosity: Optional[hypothesis.Verbosity] = None,
+) -> Generator[events.ExecutionEvent, None, None]:
+    """Prepare a generator that will run test cases against the given API definition."""
+    # pylint: disable=too-many-locals
 
+    if auth is None:
+        # Auth type doesn't matter if auth is not passed
+        auth_type = None  # type: ignore
 
-# pylint: disable=too-many-instance-attributes
-@attr.s  # pragma: no mutate
-class BaseRunner:
-    schema: BaseSchema = attr.ib()  # pragma: no mutate
-    checks: Iterable[Check] = attr.ib()  # pragma: no mutate
-    hypothesis_settings: hypothesis.settings = attr.ib(converter=get_hypothesis_settings)  # pragma: no mutate
-    auth: Optional[RawAuth] = attr.ib(default=None)  # pragma: no mutate
-    auth_type: Optional[str] = attr.ib(default=None)  # pragma: no mutate
-    headers: Optional[Dict[str, Any]] = attr.ib(default=None)  # pragma: no mutate
-    request_timeout: Optional[int] = attr.ib(default=None)  # pragma: no mutate
-    seed: Optional[int] = attr.ib(default=None)  # pragma: no mutate
-    exit_first: bool = attr.ib(default=False)  # pragma: no mutate
-
-    def execute(self,) -> Generator[events.ExecutionEvent, None, None]:
-        """Common logic for all runners."""
-        results = TestResultSet()
-
-        initialized = events.Initialized(
-            results=results, schema=self.schema, checks=self.checks, hypothesis_settings=self.hypothesis_settings
-        )
-        yield initialized
-
-        for event in self._execute(results):
-            if (
-                self.exit_first
-                and isinstance(event, events.AfterExecution)
-                and event.status in (Status.error, Status.failure)
-            ):
-                break
-            yield event
-
-        yield events.Finished(results=results, schema=self.schema, running_time=time.time() - initialized.start_time)
-
-    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
-        raise NotImplementedError
-
-
-@attr.s(slots=True)  # pragma: no mutate
-class SingleThreadRunner(BaseRunner):
-    """Fast runner that runs tests sequentially in the main thread."""
-
-    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
-        auth = get_requests_auth(self.auth, self.auth_type)
-        with get_session(auth, self.headers) as session:
-            for endpoint, test in self.schema.get_all_tests(network_test, self.hypothesis_settings, self.seed):
-                for event in run_test(
-                    self.schema,
-                    endpoint,
-                    test,
-                    self.checks,
-                    results,
-                    session=session,
-                    request_timeout=self.request_timeout,
-                ):
-                    yield event
-                    if isinstance(event, events.Interrupted):
-                        return
-
-
-@attr.s(slots=True)  # pragma: no mutate
-class SingleThreadWSGIRunner(SingleThreadRunner):
-    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
-        for endpoint, test in self.schema.get_all_tests(wsgi_test, self.hypothesis_settings, self.seed):
-            for event in run_test(
-                self.schema,
-                endpoint,
-                test,
-                self.checks,
-                results,
-                auth=self.auth,
-                auth_type=self.auth_type,
-                headers=self.headers,
-            ):
-                yield event
-                if isinstance(event, events.Interrupted):
-                    return
-
-
-def _run_task(
-    test_template: Callable,
-    tasks_queue: Queue,
-    events_queue: Queue,
-    schema: BaseSchema,
-    checks: Iterable[Check],
-    settings: hypothesis.settings,
-    seed: Optional[int],
-    results: TestResultSet,
-    **kwargs: Any,
-) -> None:
-    # pylint: disable=too-many-arguments
-    with capture_hypothesis_output():
-        while not tasks_queue.empty():
-            endpoint = tasks_queue.get()
-            test = make_test_or_exception(endpoint, test_template, settings, seed)
-            for event in run_test(schema, endpoint, test, checks, results, **kwargs):
-                events_queue.put(event)
-
-
-def thread_task(
-    tasks_queue: Queue,
-    events_queue: Queue,
-    schema: BaseSchema,
-    checks: Iterable[Check],
-    settings: hypothesis.settings,
-    auth: Optional[RawAuth],
-    auth_type: Optional[str],
-    headers: Optional[Dict[str, Any]],
-    seed: Optional[int],
-    results: TestResultSet,
-    kwargs: Any,
-) -> None:
-    """A single task, that threads do.
-
-    Pretty similar to the default one-thread flow, but includes communication with the main thread via the events queue.
-    """
-    # pylint: disable=too-many-arguments
-    prepared_auth = get_requests_auth(auth, auth_type)
-    with get_session(prepared_auth, headers) as session:
-        _run_task(
-            network_test, tasks_queue, events_queue, schema, checks, settings, seed, results, session=session, **kwargs
-        )
-
-
-def wsgi_thread_task(
-    tasks_queue: Queue,
-    events_queue: Queue,
-    schema: BaseSchema,
-    checks: Iterable[Check],
-    settings: hypothesis.settings,
-    seed: Optional[int],
-    results: TestResultSet,
-    kwargs: Any,
-) -> None:
-    # pylint: disable=too-many-arguments
-    _run_task(wsgi_test, tasks_queue, events_queue, schema, checks, settings, seed, results, **kwargs)
-
-
-def stop_worker(thread_id: int) -> None:
-    """Raise an error in a thread so it is possible to asynchronously stop thread execution."""
-    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(thread_id), ctypes.py_object(SystemExit))
-
-
-class ThreadInterrupted(Exception):
-    """Special exception when worker thread received SIGINT."""
-
-
-@attr.s(slots=True)  # pragma: no mutate
-class ThreadPoolRunner(BaseRunner):
-    """Spread different tests among multiple worker threads."""
-
-    workers_num: int = attr.ib(default=2)  # pragma: no mutate
-
-    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
-        """All events come from a queue where different workers push their events."""
-        tasks_queue = self._get_tasks_queue()
-        # Events are pushed by workers via a separate queue
-        events_queue: Queue = Queue()
-        workers = self._init_workers(tasks_queue, events_queue, results)
-
-        def stop_workers() -> None:
-            for worker in workers:
-                # workers are initialized at this point and `worker.ident` is set with an integer value
-                ident = cast(int, worker.ident)
-                stop_worker(ident)
-                worker.join()
-
-        is_finished = False
-        try:
-            while not is_finished:
-                # Sleep is needed for performance reasons
-                # each call to `is_alive` of an alive worker waits for a lock
-                # iterations without waiting are too frequent and a lot of time will be spent on waiting for this locks
-                time.sleep(0.001)
-                is_finished = all(not worker.is_alive() for worker in workers)
-                while not events_queue.empty():
-                    event = events_queue.get()
-                    yield event
-                    if isinstance(event, events.Interrupted):
-                        # Thread received SIGINT
-                        # We could still have events in the queue, but ignore them to keep the logic simple
-                        # for now, could be improved in the future to show more info in such corner cases
-                        raise ThreadInterrupted
-        except ThreadInterrupted:
-            stop_workers()
-        except KeyboardInterrupt:
-            stop_workers()
-            yield events.Interrupted(results=results, schema=self.schema)
-
-    def _get_tasks_queue(self) -> Queue:
-        """All endpoints are distributed among all workers via a queue."""
-        tasks_queue: Queue = Queue()
-        tasks_queue.queue.extend(self.schema.get_all_endpoints())
-        return tasks_queue
-
-    def _init_workers(self, tasks_queue: Queue, events_queue: Queue, results: TestResultSet) -> List[threading.Thread]:
-        """Initialize & start workers that will execute tests."""
-        workers = [
-            threading.Thread(
-                target=self._get_task(), kwargs=self._get_worker_kwargs(tasks_queue, events_queue, results)
-            )
-            for _ in range(self.workers_num)
-        ]
-        for worker in workers:
-            worker.start()
-        return workers
-
-    def _get_task(self) -> Callable:
-        return thread_task
-
-    def _get_worker_kwargs(self, tasks_queue: Queue, events_queue: Queue, results: TestResultSet) -> Dict[str, Any]:
-        return {
-            "tasks_queue": tasks_queue,
-            "events_queue": events_queue,
-            "schema": self.schema,
-            "checks": self.checks,
-            "settings": self.hypothesis_settings,
-            "auth": self.auth,
-            "auth_type": self.auth_type,
-            "headers": self.headers,
-            "seed": self.seed,
-            "results": results,
-            "kwargs": {"request_timeout": self.request_timeout},
-        }
-
-
-class ThreadPoolWSGIRunner(ThreadPoolRunner):
-    def _get_task(self) -> Callable:
-        return wsgi_thread_task
-
-    def _get_worker_kwargs(self, tasks_queue: Queue, events_queue: Queue, results: TestResultSet) -> Dict[str, Any]:
-        return {
-            "tasks_queue": tasks_queue,
-            "events_queue": events_queue,
-            "schema": self.schema,
-            "checks": self.checks,
-            "settings": self.hypothesis_settings,
-            "seed": self.seed,
-            "results": results,
-            "kwargs": {"auth": self.auth, "auth_type": self.auth_type, "headers": self.headers},
-        }
+    schema = load_schema(
+        schema_uri,
+        base_url=base_url,
+        loader=loader,
+        app=app,
+        validate_schema=validate_schema,
+        auth=auth,
+        auth_type=auth_type,
+        headers=headers,
+        endpoint=endpoint,
+        method=method,
+        tag=tag,
+    )
+    hypothesis_options = prepare_hypothesis_options(
+        deadline=hypothesis_deadline,
+        derandomize=hypothesis_derandomize,
+        max_examples=hypothesis_max_examples,
+        phases=hypothesis_phases,
+        report_multiple_bugs=hypothesis_report_multiple_bugs,
+        suppress_health_check=hypothesis_suppress_health_check,
+        verbosity=hypothesis_verbosity,
+    )
+    return execute_from_schema(
+        schema,
+        checks,
+        hypothesis_options=hypothesis_options,
+        seed=seed,
+        workers_num=workers_num,
+        exit_first=exit_first,
+        auth=auth,
+        auth_type=auth_type,
+        headers=headers,
+        request_timeout=request_timeout,
+    )
 
 
 def execute_from_schema(
     schema: BaseSchema,
-    checks: Iterable[Check],
+    checks: Iterable[CheckFunction],
     *,
     workers_num: int = 1,
     hypothesis_options: Dict[str, Any],
@@ -357,136 +156,6 @@ def execute_from_schema(
     yield from runner.execute()
 
 
-def run_test(
-    schema: BaseSchema,
-    endpoint: Endpoint,
-    test: Union[Callable, InvalidSchema],
-    checks: Iterable[Check],
-    results: TestResultSet,
-    **kwargs: Any,
-) -> Generator[events.ExecutionEvent, None, None]:
-    """A single test run with all error handling needed."""
-    # pylint: disable=too-many-arguments
-    result = TestResult(endpoint=endpoint)
-    yield events.BeforeExecution(results=results, schema=schema, endpoint=endpoint)
-    hypothesis_output: List[str] = []
-    try:
-        if isinstance(test, InvalidSchema):
-            status = Status.error
-            result.add_error(test)
-        else:
-            with capture_hypothesis_output() as hypothesis_output:
-                test(checks, result, **kwargs)
-            status = Status.success
-    except (AssertionError, hypothesis.errors.MultipleFailures):
-        status = Status.failure
-    except hypothesis.errors.Flaky:
-        status = Status.error
-        result.mark_errored()
-        # Sometimes Hypothesis detects inconsistent test results and checks are not available
-        if result.checks:
-            flaky_example = result.checks[-1].example
-        else:
-            flaky_example = None
-        result.add_error(
-            hypothesis.errors.Flaky(
-                "Tests on this endpoint produce unreliable results: \n"
-                "Falsified on the first call but did not on a subsequent one"
-            ),
-            flaky_example,
-        )
-    except hypothesis.errors.Unsatisfiable:
-        # We need more clear error message here
-        status = Status.error
-        result.add_error(hypothesis.errors.Unsatisfiable("Unable to satisfy schema parameters for this endpoint"))
-    except KeyboardInterrupt:
-        yield events.Interrupted(results=results, schema=schema)
-        return
-    except Exception as error:
-        status = Status.error
-        result.add_error(error)
-    # Fetch seed value, hypothesis generates it during test execution
-    result.seed = getattr(test, "_hypothesis_internal_use_seed", None) or getattr(
-        test, "_hypothesis_internal_use_generated_seed", None
-    )
-    results.append(result)
-    yield events.AfterExecution(
-        results=results, schema=schema, endpoint=endpoint, status=status, hypothesis_output=hypothesis_output
-    )
-
-
-def prepare(  # pylint: disable=too-many-arguments
-    schema_uri: str,
-    *,
-    # Runtime behavior
-    checks: Iterable[Check] = DEFAULT_CHECKS,
-    workers_num: int = 1,
-    seed: Optional[int] = None,
-    exit_first: bool = False,
-    # Schema loading
-    loader: Callable = loaders.from_uri,
-    base_url: Optional[str] = None,
-    auth: Optional[Tuple[str, str]] = None,
-    auth_type: Optional[str] = None,
-    headers: Optional[Dict[str, str]] = None,
-    request_timeout: Optional[int] = None,
-    endpoint: Optional[Filter] = None,
-    method: Optional[Filter] = None,
-    tag: Optional[Filter] = None,
-    app: Any = None,
-    validate_schema: bool = True,
-    # Hypothesis-specific configuration
-    hypothesis_deadline: Optional[Union[int, NotSet]] = None,
-    hypothesis_derandomize: Optional[bool] = None,
-    hypothesis_max_examples: Optional[int] = None,
-    hypothesis_phases: Optional[List[hypothesis.Phase]] = None,
-    hypothesis_report_multiple_bugs: Optional[bool] = None,
-    hypothesis_suppress_health_check: Optional[List[hypothesis.HealthCheck]] = None,
-    hypothesis_verbosity: Optional[hypothesis.Verbosity] = None,
-) -> Generator[events.ExecutionEvent, None, None]:
-    """Prepare a generator that will run test cases against the given API definition."""
-    # pylint: disable=too-many-locals
-
-    if auth is None:
-        # Auth type doesn't matter if auth is not passed
-        auth_type = None  # type: ignore
-
-    schema = load_schema(
-        schema_uri,
-        base_url=base_url,
-        loader=loader,
-        app=app,
-        validate_schema=validate_schema,
-        auth=auth,
-        auth_type=auth_type,
-        headers=headers,
-        endpoint=endpoint,
-        method=method,
-        tag=tag,
-    )
-    hypothesis_options = prepare_hypothesis_options(
-        deadline=hypothesis_deadline,
-        derandomize=hypothesis_derandomize,
-        max_examples=hypothesis_max_examples,
-        phases=hypothesis_phases,
-        report_multiple_bugs=hypothesis_report_multiple_bugs,
-        suppress_health_check=hypothesis_suppress_health_check,
-        verbosity=hypothesis_verbosity,
-    )
-    return execute_from_schema(
-        schema,
-        checks,
-        hypothesis_options=hypothesis_options,
-        seed=seed,
-        workers_num=workers_num,
-        exit_first=exit_first,
-        auth=auth,
-        auth_type=auth_type,
-        headers=headers,
-        request_timeout=request_timeout,
-    )
-
-
 def load_schema(
     schema_uri: str,
     *,
@@ -547,91 +216,3 @@ def prepare_hypothesis_options(  # pylint: disable=too-many-arguments
         else:
             options["deadline"] = deadline
     return options
-
-
-def network_test(
-    case: Case, checks: Iterable[Check], result: TestResult, session: requests.Session, request_timeout: Optional[int]
-) -> None:
-    """A single test body that will be executed against the target."""
-    # pylint: disable=too-many-arguments
-    timeout = prepare_timeout(request_timeout)
-    response = case.call(session=session, timeout=timeout)
-    _run_checks(case, checks, result, response)
-
-
-def wsgi_test(
-    case: Case,
-    checks: Iterable[Check],
-    result: TestResult,
-    auth: Optional[RawAuth],
-    auth_type: Optional[str],
-    headers: Optional[Dict[str, Any]],
-) -> None:
-    # pylint: disable=too-many-arguments
-    headers = _prepare_wsgi_headers(headers, auth, auth_type)
-    with catching_logs(LogCaptureHandler(), level=logging.DEBUG) as recorded:
-        response = case.call_wsgi(headers=headers)
-    result.logs.extend(recorded.records)
-    _run_checks(case, checks, result, response)
-
-
-def _prepare_wsgi_headers(
-    headers: Optional[Dict[str, Any]], auth: Optional[RawAuth], auth_type: Optional[str]
-) -> Dict[str, Any]:
-    headers = headers or {}
-    headers.setdefault("User-agent", USER_AGENT)
-    wsgi_auth = get_wsgi_auth(auth, auth_type)
-    if wsgi_auth:
-        headers["Authorization"] = wsgi_auth
-    return headers
-
-
-def _run_checks(case: Case, checks: Iterable[Check], result: TestResult, response: GenericResponse) -> None:
-    errors = []
-
-    for check in checks:
-        check_name = check.__name__
-        try:
-            check(response, case)
-            result.add_success(check_name, case)
-        except AssertionError as exc:
-            errors.append(exc)
-            result.add_failure(check_name, case, str(exc))
-
-    if errors:
-        raise get_grouped_exception(*errors)
-
-
-def prepare_timeout(timeout: Optional[int]) -> Optional[float]:
-    """Request timeout is in milliseconds, but `requests` uses seconds."""
-    output: Optional[Union[int, float]] = timeout
-    if timeout is not None:
-        output = timeout / 1000
-    return output
-
-
-@contextmanager
-def get_session(
-    auth: Optional[Union[HTTPDigestAuth, RawAuth]] = None, headers: Optional[Dict[str, Any]] = None
-) -> Generator[requests.Session, None, None]:
-    with requests.Session() as session:
-        if auth is not None:
-            session.auth = auth
-        session.headers["User-agent"] = USER_AGENT
-        if headers is not None:
-            session.headers.update(**headers)
-        yield session
-
-
-def get_requests_auth(auth: Optional[RawAuth], auth_type: Optional[str]) -> Optional[Union[HTTPDigestAuth, RawAuth]]:
-    if auth and auth_type == "digest":
-        return HTTPDigestAuth(*auth)
-    return auth
-
-
-def get_wsgi_auth(auth: Optional[RawAuth], auth_type: Optional[str]) -> Optional[str]:
-    if auth:
-        if auth_type == "digest":
-            raise ValueError("Digest auth is not supported for WSGI apps")
-        return _basic_auth_str(*auth)
-    return None

--- a/src/schemathesis/runner/impl/__init__.py
+++ b/src/schemathesis/runner/impl/__init__.py
@@ -1,0 +1,3 @@
+from .core import BaseRunner
+from .solo import SingleThreadRunner, SingleThreadWSGIRunner
+from .threadpool import ThreadPoolRunner, ThreadPoolWSGIRunner

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -1,0 +1,207 @@
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Union
+
+import attr
+import hypothesis
+import requests
+from _pytest.logging import LogCaptureHandler, catching_logs
+from requests.auth import HTTPDigestAuth, _basic_auth_str
+
+from ...constants import USER_AGENT
+from ...exceptions import InvalidSchema, get_grouped_exception
+from ...models import Case, CheckFunction, Endpoint, Status, TestResult, TestResultSet
+from ...runner import events
+from ...schemas import BaseSchema
+from ...types import RawAuth
+from ...utils import GenericResponse, capture_hypothesis_output
+
+DEFAULT_DEADLINE = 500  # pragma: no mutate
+
+
+def get_hypothesis_settings(hypothesis_options: Dict[str, Any]) -> hypothesis.settings:
+    # Default settings, used as a parent settings object below
+    hypothesis_options.setdefault("deadline", DEFAULT_DEADLINE)
+    return hypothesis.settings(**hypothesis_options)
+
+
+# pylint: disable=too-many-instance-attributes
+@attr.s  # pragma: no mutate
+class BaseRunner:
+    schema: BaseSchema = attr.ib()  # pragma: no mutate
+    checks: Iterable[CheckFunction] = attr.ib()  # pragma: no mutate
+    hypothesis_settings: hypothesis.settings = attr.ib(converter=get_hypothesis_settings)  # pragma: no mutate
+    auth: Optional[RawAuth] = attr.ib(default=None)  # pragma: no mutate
+    auth_type: Optional[str] = attr.ib(default=None)  # pragma: no mutate
+    headers: Optional[Dict[str, Any]] = attr.ib(default=None)  # pragma: no mutate
+    request_timeout: Optional[int] = attr.ib(default=None)  # pragma: no mutate
+    seed: Optional[int] = attr.ib(default=None)  # pragma: no mutate
+    exit_first: bool = attr.ib(default=False)  # pragma: no mutate
+
+    def execute(self,) -> Generator[events.ExecutionEvent, None, None]:
+        """Common logic for all runners."""
+        results = TestResultSet()
+
+        initialized = events.Initialized(
+            results=results, schema=self.schema, checks=self.checks, hypothesis_settings=self.hypothesis_settings
+        )
+        yield initialized
+
+        for event in self._execute(results):
+            if (
+                self.exit_first
+                and isinstance(event, events.AfterExecution)
+                and event.status in (Status.error, Status.failure)
+            ):
+                break
+            yield event
+
+        yield events.Finished(results=results, schema=self.schema, running_time=time.time() - initialized.start_time)
+
+    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
+        raise NotImplementedError
+
+
+def run_test(
+    schema: BaseSchema,
+    endpoint: Endpoint,
+    test: Union[Callable, InvalidSchema],
+    checks: Iterable[CheckFunction],
+    results: TestResultSet,
+    **kwargs: Any,
+) -> Generator[events.ExecutionEvent, None, None]:
+    """A single test run with all error handling needed."""
+    # pylint: disable=too-many-arguments
+    result = TestResult(endpoint=endpoint)
+    yield events.BeforeExecution(results=results, schema=schema, endpoint=endpoint)
+    hypothesis_output: List[str] = []
+    try:
+        if isinstance(test, InvalidSchema):
+            status = Status.error
+            result.add_error(test)
+        else:
+            with capture_hypothesis_output() as hypothesis_output:
+                test(checks, result, **kwargs)
+            status = Status.success
+    except (AssertionError, hypothesis.errors.MultipleFailures):
+        status = Status.failure
+    except hypothesis.errors.Flaky:
+        status = Status.error
+        result.mark_errored()
+        # Sometimes Hypothesis detects inconsistent test results and checks are not available
+        if result.checks:
+            flaky_example = result.checks[-1].example
+        else:
+            flaky_example = None
+        result.add_error(
+            hypothesis.errors.Flaky(
+                "Tests on this endpoint produce unreliable results: \n"
+                "Falsified on the first call but did not on a subsequent one"
+            ),
+            flaky_example,
+        )
+    except hypothesis.errors.Unsatisfiable:
+        # We need more clear error message here
+        status = Status.error
+        result.add_error(hypothesis.errors.Unsatisfiable("Unable to satisfy schema parameters for this endpoint"))
+    except KeyboardInterrupt:
+        yield events.Interrupted(results=results, schema=schema)
+        return
+    except Exception as error:
+        status = Status.error
+        result.add_error(error)
+    # Fetch seed value, hypothesis generates it during test execution
+    result.seed = getattr(test, "_hypothesis_internal_use_seed", None) or getattr(
+        test, "_hypothesis_internal_use_generated_seed", None
+    )
+    results.append(result)
+    yield events.AfterExecution(
+        results=results, schema=schema, endpoint=endpoint, status=status, hypothesis_output=hypothesis_output
+    )
+
+
+def run_checks(case: Case, checks: Iterable[CheckFunction], result: TestResult, response: GenericResponse) -> None:
+    errors = []
+
+    for check in checks:
+        check_name = check.__name__
+        try:
+            check(response, case)
+            result.add_success(check_name, case)
+        except AssertionError as exc:
+            errors.append(exc)
+            result.add_failure(check_name, case, str(exc))
+
+    if errors:
+        raise get_grouped_exception(*errors)
+
+
+def network_test(
+    case: Case,
+    checks: Iterable[CheckFunction],
+    result: TestResult,
+    session: requests.Session,
+    request_timeout: Optional[int],
+) -> None:
+    """A single test body that will be executed against the target."""
+    # pylint: disable=too-many-arguments
+    timeout = prepare_timeout(request_timeout)
+    response = case.call(session=session, timeout=timeout)
+    run_checks(case, checks, result, response)
+
+
+@contextmanager
+def get_session(
+    auth: Optional[Union[HTTPDigestAuth, RawAuth]] = None, headers: Optional[Dict[str, Any]] = None
+) -> Generator[requests.Session, None, None]:
+    with requests.Session() as session:
+        if auth is not None:
+            session.auth = auth
+        session.headers["User-agent"] = USER_AGENT
+        if headers is not None:
+            session.headers.update(**headers)
+        yield session
+
+
+def prepare_timeout(timeout: Optional[int]) -> Optional[float]:
+    """Request timeout is in milliseconds, but `requests` uses seconds."""
+    output: Optional[Union[int, float]] = timeout
+    if timeout is not None:
+        output = timeout / 1000
+    return output
+
+
+def wsgi_test(
+    case: Case,
+    checks: Iterable[CheckFunction],
+    result: TestResult,
+    auth: Optional[RawAuth],
+    auth_type: Optional[str],
+    headers: Optional[Dict[str, Any]],
+) -> None:
+    # pylint: disable=too-many-arguments
+    headers = _prepare_wsgi_headers(headers, auth, auth_type)
+    with catching_logs(LogCaptureHandler(), level=logging.DEBUG) as recorded:
+        response = case.call_wsgi(headers=headers)
+    result.logs.extend(recorded.records)
+    run_checks(case, checks, result, response)
+
+
+def _prepare_wsgi_headers(
+    headers: Optional[Dict[str, Any]], auth: Optional[RawAuth], auth_type: Optional[str]
+) -> Dict[str, Any]:
+    headers = headers or {}
+    headers.setdefault("User-agent", USER_AGENT)
+    wsgi_auth = get_wsgi_auth(auth, auth_type)
+    if wsgi_auth:
+        headers["Authorization"] = wsgi_auth
+    return headers
+
+
+def get_wsgi_auth(auth: Optional[RawAuth], auth_type: Optional[str]) -> Optional[str]:
+    if auth:
+        if auth_type == "digest":
+            raise ValueError("Digest auth is not supported for WSGI apps")
+        return _basic_auth_str(*auth)
+    return None

--- a/src/schemathesis/runner/impl/solo.py
+++ b/src/schemathesis/runner/impl/solo.py
@@ -1,0 +1,50 @@
+# weird mypy bug with imports
+from typing import Any, Dict, Generator  # pylint: disable=unused-import
+
+import attr
+
+from ...models import TestResultSet
+from ...utils import get_requests_auth
+from .. import events
+from .core import BaseRunner, get_session, network_test, run_test, wsgi_test
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SingleThreadRunner(BaseRunner):
+    """Fast runner that runs tests sequentially in the main thread."""
+
+    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
+        auth = get_requests_auth(self.auth, self.auth_type)
+        with get_session(auth, self.headers) as session:
+            for endpoint, test in self.schema.get_all_tests(network_test, self.hypothesis_settings, self.seed):
+                for event in run_test(
+                    self.schema,
+                    endpoint,
+                    test,
+                    self.checks,
+                    results,
+                    session=session,
+                    request_timeout=self.request_timeout,
+                ):
+                    yield event
+                    if isinstance(event, events.Interrupted):
+                        return
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SingleThreadWSGIRunner(SingleThreadRunner):
+    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
+        for endpoint, test in self.schema.get_all_tests(wsgi_test, self.hypothesis_settings, self.seed):
+            for event in run_test(
+                self.schema,
+                endpoint,
+                test,
+                self.checks,
+                results,
+                auth=self.auth,
+                auth_type=self.auth_type,
+                headers=self.headers,
+            ):
+                yield event
+                if isinstance(event, events.Interrupted):
+                    return

--- a/src/schemathesis/runner/impl/threadpool.py
+++ b/src/schemathesis/runner/impl/threadpool.py
@@ -1,0 +1,180 @@
+import ctypes
+import threading
+import time
+from queue import Queue
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, cast
+
+import attr
+import hypothesis
+
+from ..._hypothesis import make_test_or_exception
+from ...models import CheckFunction, TestResultSet
+from ...schemas import BaseSchema
+from ...types import RawAuth
+from ...utils import capture_hypothesis_output, get_requests_auth
+from .. import events
+from .core import BaseRunner, get_session, network_test, run_test, wsgi_test
+
+
+def _run_task(
+    test_template: Callable,
+    tasks_queue: Queue,
+    events_queue: Queue,
+    schema: BaseSchema,
+    checks: Iterable[CheckFunction],
+    settings: hypothesis.settings,
+    seed: Optional[int],
+    results: TestResultSet,
+    **kwargs: Any,
+) -> None:
+    # pylint: disable=too-many-arguments
+    with capture_hypothesis_output():
+        while not tasks_queue.empty():
+            endpoint = tasks_queue.get()
+            test = make_test_or_exception(endpoint, test_template, settings, seed)
+            for event in run_test(schema, endpoint, test, checks, results, **kwargs):
+                events_queue.put(event)
+
+
+def thread_task(
+    tasks_queue: Queue,
+    events_queue: Queue,
+    schema: BaseSchema,
+    checks: Iterable[CheckFunction],
+    settings: hypothesis.settings,
+    auth: Optional[RawAuth],
+    auth_type: Optional[str],
+    headers: Optional[Dict[str, Any]],
+    seed: Optional[int],
+    results: TestResultSet,
+    kwargs: Any,
+) -> None:
+    """A single task, that threads do.
+
+    Pretty similar to the default one-thread flow, but includes communication with the main thread via the events queue.
+    """
+    # pylint: disable=too-many-arguments
+    prepared_auth = get_requests_auth(auth, auth_type)
+    with get_session(prepared_auth, headers) as session:
+        _run_task(
+            network_test, tasks_queue, events_queue, schema, checks, settings, seed, results, session=session, **kwargs
+        )
+
+
+def wsgi_thread_task(
+    tasks_queue: Queue,
+    events_queue: Queue,
+    schema: BaseSchema,
+    checks: Iterable[CheckFunction],
+    settings: hypothesis.settings,
+    seed: Optional[int],
+    results: TestResultSet,
+    kwargs: Any,
+) -> None:
+    # pylint: disable=too-many-arguments
+    _run_task(wsgi_test, tasks_queue, events_queue, schema, checks, settings, seed, results, **kwargs)
+
+
+def stop_worker(thread_id: int) -> None:
+    """Raise an error in a thread so it is possible to asynchronously stop thread execution."""
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(thread_id), ctypes.py_object(SystemExit))
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class ThreadPoolRunner(BaseRunner):
+    """Spread different tests among multiple worker threads."""
+
+    workers_num: int = attr.ib(default=2)  # pragma: no mutate
+
+    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
+        """All events come from a queue where different workers push their events."""
+        tasks_queue = self._get_tasks_queue()
+        # Events are pushed by workers via a separate queue
+        events_queue: Queue = Queue()
+        workers = self._init_workers(tasks_queue, events_queue, results)
+
+        def stop_workers() -> None:
+            for worker in workers:
+                # workers are initialized at this point and `worker.ident` is set with an integer value
+                ident = cast(int, worker.ident)
+                stop_worker(ident)
+                worker.join()
+
+        is_finished = False
+        try:
+            while not is_finished:
+                # Sleep is needed for performance reasons
+                # each call to `is_alive` of an alive worker waits for a lock
+                # iterations without waiting are too frequent and a lot of time will be spent on waiting for this locks
+                time.sleep(0.001)
+                is_finished = all(not worker.is_alive() for worker in workers)
+                while not events_queue.empty():
+                    event = events_queue.get()
+                    yield event
+                    if isinstance(event, events.Interrupted):
+                        # Thread received SIGINT
+                        # We could still have events in the queue, but ignore them to keep the logic simple
+                        # for now, could be improved in the future to show more info in such corner cases
+                        raise ThreadInterrupted
+        except ThreadInterrupted:
+            stop_workers()
+        except KeyboardInterrupt:
+            stop_workers()
+            yield events.Interrupted(results=results, schema=self.schema)
+
+    def _get_tasks_queue(self) -> Queue:
+        """All endpoints are distributed among all workers via a queue."""
+        tasks_queue: Queue = Queue()
+        tasks_queue.queue.extend(self.schema.get_all_endpoints())
+        return tasks_queue
+
+    def _init_workers(self, tasks_queue: Queue, events_queue: Queue, results: TestResultSet) -> List[threading.Thread]:
+        """Initialize & start workers that will execute tests."""
+        workers = [
+            threading.Thread(
+                target=self._get_task(), kwargs=self._get_worker_kwargs(tasks_queue, events_queue, results)
+            )
+            for _ in range(self.workers_num)
+        ]
+        for worker in workers:
+            worker.start()
+        return workers
+
+    def _get_task(self) -> Callable:
+        return thread_task
+
+    def _get_worker_kwargs(self, tasks_queue: Queue, events_queue: Queue, results: TestResultSet) -> Dict[str, Any]:
+        return {
+            "tasks_queue": tasks_queue,
+            "events_queue": events_queue,
+            "schema": self.schema,
+            "checks": self.checks,
+            "settings": self.hypothesis_settings,
+            "auth": self.auth,
+            "auth_type": self.auth_type,
+            "headers": self.headers,
+            "seed": self.seed,
+            "results": results,
+            "kwargs": {"request_timeout": self.request_timeout},
+        }
+
+
+class ThreadPoolWSGIRunner(ThreadPoolRunner):
+    def _get_task(self) -> Callable:
+        return wsgi_thread_task
+
+    def _get_worker_kwargs(self, tasks_queue: Queue, events_queue: Queue, results: TestResultSet) -> Dict[str, Any]:
+        return {
+            "tasks_queue": tasks_queue,
+            "events_queue": events_queue,
+            "schema": self.schema,
+            "checks": self.checks,
+            "settings": self.hypothesis_settings,
+            "seed": self.seed,
+            "results": results,
+            "kwargs": {"auth": self.auth, "auth_type": self.auth_type, "headers": self.headers},
+        }
+
+
+class ThreadInterrupted(Exception):
+    """Special exception when worker thread received SIGINT."""

--- a/src/schemathesis/types.py
+++ b/src/schemathesis/types.py
@@ -22,3 +22,5 @@ class NotSet:
 Filter = Union[str, List[str], Tuple[str], Set[str], NotSet]  # pragma: no mutate
 
 Hook = Callable[[SearchStrategy], SearchStrategy]  # pragma: no mutate
+
+RawAuth = Tuple[str, str]  # pragma: no mutate

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -3,17 +3,19 @@ import pathlib
 import re
 import traceback
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, List, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union
 from urllib.parse import urlsplit, urlunsplit
 
+import requests
 import yaml
 from hypothesis.reporting import with_reporter
+from requests.auth import HTTPDigestAuth
 from requests.exceptions import InvalidHeader  # type: ignore
 from requests.utils import check_header_validity  # type: ignore
 from werkzeug.wrappers import Response as BaseResponse
 from werkzeug.wrappers.json import JSONMixin
 
-from .types import Filter, NotSet
+from .types import Filter, NotSet, RawAuth
 
 NOT_SET = NotSet()
 
@@ -151,3 +153,12 @@ StringDatesYAMLLoader = make_loader("tag:yaml.org,2002:timestamp")
 
 class WSGIResponse(BaseResponse, JSONMixin):  # pylint: disable=too-many-ancestors
     pass
+
+
+def get_requests_auth(auth: Optional[RawAuth], auth_type: Optional[str]) -> Optional[Union[HTTPDigestAuth, RawAuth]]:
+    if auth and auth_type == "digest":
+        return HTTPDigestAuth(*auth)
+    return auth
+
+
+GenericResponse = Union[requests.Response, WSGIResponse]  # pragma: no mutate

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -838,7 +838,7 @@ def test_keyboard_interrupt_threaded(cli, cli_args, mocker):
             raise KeyboardInterrupt
         return original(*args, **kwargs)
 
-    mocker.patch("schemathesis.runner.time.sleep", autospec=True, wraps=mocked)
+    mocker.patch("schemathesis.runner.impl.threadpool.time.sleep", autospec=True, wraps=mocked)
     result = cli.run(*cli_args, "--workers=2")
     # the exit status depends on what thread finished first
     assert result.exit_code in (ExitCode.OK, ExitCode.TESTS_FAILED)

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -18,7 +18,8 @@ from schemathesis.checks import (
 from schemathesis.constants import __version__
 from schemathesis.exceptions import InvalidSchema
 from schemathesis.models import Status
-from schemathesis.runner import events, get_base_url, get_requests_auth, get_wsgi_auth, prepare
+from schemathesis.runner import events, get_base_url, get_requests_auth, prepare
+from schemathesis.runner.impl.core import get_wsgi_auth
 
 
 def execute(schema_uri, checks=DEFAULT_CHECKS, loader=from_uri, **options):


### PR DESCRIPTION
 Different runner types are placed in different modules. It is a preparation for a new runner type - `subprocess`, which will be helpful when it is not desirable to use the runner in the same thread, e.g. web app (since hypothesis runs a CPU intensive load it will affect the web thread performance). Running the whole runner in a separate process won't help much since there is no built-in way to communicate with that spawned process - this part will be implemented in a new runner type, so the client can just consume events as with any other runner type