### PR TITLE
fix: Handling of fields in `paths` that are not operations, but allowed by the Open API spec

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Handling of fields in ``paths`` that are not operations, but allowed by the Open API spec. `#457`_
+
 `1.0.1`_ - 2020-04-01
 ---------------------
 
@@ -819,6 +824,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#457: https://github.com/kiwicom/schemathesis/issues/457
 .. _#450: https://github.com/kiwicom/schemathesis/issues/450
 .. _#448: https://github.com/kiwicom/schemathesis/issues/448
 .. _#440: https://github.com/kiwicom/schemathesis/issues/440

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -169,6 +169,7 @@ class BaseSchema(Mapping):
 
 class SwaggerV20(BaseSchema):
     nullable_name = "x-nullable"
+    operations: Tuple[str, ...] = ("get", "put", "post", "delete", "options", "head", "patch")
 
     def __repr__(self) -> str:
         info = self.raw_schema["info"]
@@ -206,8 +207,7 @@ class SwaggerV20(BaseSchema):
                 for method, definition in methods.items():
                     # Only method definitions are parsed
                     if (
-                        method == "parameters"
-                        or method.startswith("x-")
+                        method not in self.operations
                         or should_skip_method(method, self.method)
                         or should_skip_by_tag(definition.get("tags"), self.tag)
                     ):
@@ -321,6 +321,7 @@ class SwaggerV20(BaseSchema):
 
 class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
     nullable_name = "nullable"
+    operations = SwaggerV20.operations + ("trace",)
 
     @property
     def spec_version(self) -> str:


### PR DESCRIPTION
Fixes #457 