### PR TITLE
fix: Pytest 5.4 warning about deprecated `Node` initialization usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,3 +136,38 @@ jobs:
         file: ./coverage.xml
         flags: unittests
         name: codecov-py36
+
+  pytest-legacy:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        tox_job:
+          - py3-pytest53
+
+    name: ${{ matrix.os }}/tests_${{ matrix.tox_job }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - run: pip install tox coverage
+
+    - name: Run ${{ matrix.tox_job }} tox job
+      run: tox -e ${{ matrix.tox_job }}
+
+    - run: coverage combine
+    - run: coverage report
+    - run: coverage xml -i
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-py36-legacy-pytest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Fixed
 ~~~~~
 
 - Handling of fields in ``paths`` that are not operations, but allowed by the Open API spec. `#457`_
+- Pytest 5.4 warning about deprecated ``Node`` initialization usage. `#451`_
 
 `1.0.1`_ - 2020-04-01
 ---------------------
@@ -825,6 +826,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#457: https://github.com/kiwicom/schemathesis/issues/457
+.. _#451: https://github.com/kiwicom/schemathesis/issues/451
 .. _#450: https://github.com/kiwicom/schemathesis/issues/450
 .. _#448: https://github.com/kiwicom/schemathesis/issues/448
 .. _#440: https://github.com/kiwicom/schemathesis/issues/440

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "pytest", "pytest_subtests", "requests", "schemathesis", "werkzeug", "yaml"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "werkzeug", "yaml"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -94,3 +94,18 @@ def test_schemathesis():
     result = testdir.runpytest()
     # It shouldn't be collected as a test
     result.assert_outcomes(passed=1)
+
+
+def test_pytest_warning(testdir):
+    testdir.make_test(
+        """
+@schema.parametrize()
+@pytest.mark.parametrize("a", (1, 2))
+def test_schemathesis(case, a):
+    assert True
+""",
+    )
+    # When a test is run with treating warnings as errors
+    result = testdir.runpytest("-Werror")
+    # There should be no errors. There are no warnings from Schemathesis pytest plugin
+    result.assert_outcomes(passed=2)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ isolated_build = true
 envlist =
   pylint,mypy,
   py{36,37,38},
+  py3-pytest53
   py3-hypothesis-{4.40,4.50,5.0,5.1}
   coverage-report
 
@@ -19,6 +20,7 @@ deps =
   hypothesis-4.50: hypothesis>=4.50,<5.0
   hypothesis-5.0: hypothesis>=5.0,<5.1
   hypothesis-5.1: hypothesis>=5.1,<5.2
+  pytest53: pytest<5.4
 commands =
   coverage run --source=schemathesis -m pytest {posargs:} test
 


### PR DESCRIPTION
Resolve #451 
I don't want to drop support for pytest<5.4