### PR TITLE
fix: Precedence of `produces` keywords for Swagger 2.0 schemas

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Precedence of ``produces`` keywords for Swagger 2.0 schemas. Now, operation-level ``produces`` overrides
+  schema-level ``produces`` as specified in the specification. `#463`_
+
 `1.0.2`_ - 2020-04-02
 ---------------------
 
@@ -829,6 +835,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#463: https://github.com/kiwicom/schemathesis/issues/463
 .. _#457: https://github.com/kiwicom/schemathesis/issues/457
 .. _#451: https://github.com/kiwicom/schemathesis/issues/451
 .. _#450: https://github.com/kiwicom/schemathesis/issues/450

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -45,11 +45,10 @@ def _expand_responses(responses: Dict[Union[str, int], Any]) -> Generator[int, N
 
 
 def content_type_conformance(response: GenericResponse, case: "Case") -> None:
+    produces = case.endpoint.definition.get("produces", None)
     global_produces = case.endpoint.schema.raw_schema.get("produces", None)
-    if global_produces:
+    if global_produces and not produces:
         produces = global_produces
-    else:
-        produces = case.endpoint.definition.get("produces", None)
     if not produces:
         return
     content_type = response.headers["Content-Type"]


### PR DESCRIPTION
Fixes #463 