### PR TITLE
Subprocess running mode

### DIFF
--- a/src/schemathesis/cli/context.py
+++ b/src/schemathesis/cli/context.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from typing import List
+from typing import List, Optional
 
 import attr
 
@@ -13,5 +13,7 @@ class ExecutionContext:
     workers_num: int = attr.ib(default=1)  # pragma: no mutate
     show_errors_tracebacks: bool = attr.ib(default=False)  # pragma: no mutate
     endpoints_processed: int = attr.ib(default=0)  # pragma: no mutate
+    # It is set in runtime, from a `Initialized` event
+    endpoints_count: Optional[int] = attr.ib(default=None)  # pragma: no mutate
     current_line_length: int = attr.ib(default=0)  # pragma: no mutate
     terminal_size: os.terminal_size = attr.ib(factory=shutil.get_terminal_size)  # pragma: no mutate

--- a/src/schemathesis/cli/output/short.py
+++ b/src/schemathesis/cli/output/short.py
@@ -8,7 +8,7 @@ from . import default
 def handle_after_execution(context: ExecutionContext, event: events.AfterExecution) -> None:
     context.endpoints_processed += 1
     default.display_execution_result(context, event)
-    if context.endpoints_processed == event.schema.endpoints_count:
+    if context.endpoints_processed == context.endpoints_count:
         click.echo()
 
 
@@ -26,3 +26,5 @@ def handle_event(context: ExecutionContext, event: events.ExecutionEvent) -> Non
         default.handle_finished(context, event)
     if isinstance(event, events.Interrupted):
         default.handle_interrupted(context, event)
+    if isinstance(event, events.InternalError):
+        default.handle_internal_error(context, event)

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -1,33 +1,43 @@
+# pylint: disable=too-many-instance-attributes
 import time
-from typing import Callable, Iterable, List
+from typing import Dict, List, Optional, Union
 
 import attr
-import hypothesis
+from requests import exceptions
 
+from ..exceptions import HTTPError
 from ..models import Endpoint, Status, TestResultSet
 from ..schemas import BaseSchema
+from ..utils import format_exception
+from .serialization import SerializedTestResult
 
 
 @attr.s()  # pragma: no mutate
 class ExecutionEvent:
     """Generic execution event."""
 
-    # Holder for all tests results in a particular run
-    results: TestResultSet = attr.ib()  # pragma: no mutate
-    # Schema that is being tested
-    schema: BaseSchema = attr.ib()  # pragma: no mutate
-
 
 @attr.s(slots=True)  # pragma: no mutate
 class Initialized(ExecutionEvent):
     """Runner is initialized, settings are prepared, requests session is ready."""
 
-    # List of checks that will be used during the run
-    checks: Iterable[Callable] = attr.ib()  # pragma: no mutate
-    # Settings for `hypothesis` tests
-    hypothesis_settings: hypothesis.settings = attr.ib()  # pragma: no mutate
+    # Total number of endpoints in the schema
+    endpoints_count: int = attr.ib()  # pragma: no mutate
+    location: Optional[str] = attr.ib()
+    base_url: Optional[str] = attr.ib()
+    specification_name: str = attr.ib()
     # Timestamp of test run start
     start_time: float = attr.ib(factory=time.monotonic)
+
+    @classmethod
+    def from_schema(cls, *, schema: BaseSchema) -> "Initialized":
+        """Computes all needed data from the schema instance."""
+        return cls(
+            endpoints_count=schema.endpoints_count,
+            location=schema.location,
+            base_url=schema.base_url,
+            specification_name=schema.verbose_name,
+        )
 
 
 @attr.s(slots=True)  # pragma: no mutate
@@ -37,15 +47,18 @@ class BeforeExecution(ExecutionEvent):
     It happens before a single hypothesis test, that may contain many examples inside.
     """
 
-    # Endpoint being tested
-    endpoint: Endpoint = attr.ib()  # pragma: no mutate
+    method: str = attr.ib()  # pragma: no mutate
+    path: str = attr.ib()  # pragma: no mutate
+
+    @classmethod
+    def from_endpoint(cls, endpoint: Endpoint) -> "BeforeExecution":
+        return cls(method=endpoint.method, path=endpoint.path)
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class AfterExecution(ExecutionEvent):
     """Happens after each examined endpoint."""
 
-    endpoint: Endpoint = attr.ib()  # pragma: no mutate
     # Endpoint test status - success / failure / error
     status: Status = attr.ib()  # pragma: no mutate
     # Captured hypothesis stdout
@@ -58,11 +71,60 @@ class Interrupted(ExecutionEvent):
 
 
 @attr.s(slots=True)  # pragma: no mutate
+class InternalError(ExecutionEvent):
+    """An error that happened inside the runner."""
+
+    message: str = attr.ib()
+    exception: Optional[str] = attr.ib(default=None)
+
+    @classmethod
+    def from_exc(cls, exc: Exception) -> "InternalError":
+        if isinstance(exc, HTTPError):
+            if exc.response.status_code == 404:
+                message = f"Schema was not found at {exc.url}"
+            else:
+                message = f"Failed to load schema, code {exc.response.status_code} was returned from {exc.url}"
+            return cls(message=message)
+        if isinstance(exc, exceptions.ConnectionError):
+            return cls(message=f"Failed to load schema from {exc.request.url}", exception=format_exception(exc),)
+        return cls(message="An internal error happened during a test run", exception=format_exception(exc),)
+
+
+@attr.s(slots=True)  # pragma: no mutate
 class Finished(ExecutionEvent):
     """The final event of the run.
 
     No more events after this point.
     """
 
+    # Holder for all tests results in a particular run
+    results: List[SerializedTestResult] = attr.ib()  # pragma: no mutate
+
+    passed_count: int = attr.ib()
+    failed_count: int = attr.ib()
+    errored_count: int = attr.ib()
+
+    has_failures: bool = attr.ib()
+    has_errors: bool = attr.ib()
+    has_logs: bool = attr.ib()
+    is_empty: bool = attr.ib()
+
+    total: Dict[str, Dict[Union[str, Status], int]] = attr.ib()
+
     # Total test run execution time
     running_time: float = attr.ib()
+
+    @classmethod
+    def from_results(cls, results: TestResultSet, running_time: float) -> "Finished":
+        return cls(
+            passed_count=results.passed_count,
+            failed_count=results.failed_count,
+            errored_count=results.errored_count,
+            has_failures=results.has_failures,
+            has_errors=results.has_errors,
+            has_logs=results.has_logs,
+            is_empty=results.is_empty,
+            total=results.total,
+            results=[SerializedTestResult.from_test_result(result) for result in results],
+            running_time=running_time,
+        )

--- a/src/schemathesis/runner/executors.py
+++ b/src/schemathesis/runner/executors.py
@@ -1,0 +1,181 @@
+import multiprocessing
+from queue import Empty
+from typing import Any, Callable, Dict, Generator, Iterable, Optional, Tuple
+from urllib.parse import urlparse
+
+import attr
+
+from .. import loaders
+from ..models import CheckFunction
+from ..schemas import BaseSchema
+from ..types import Filter, RawAuth
+from ..utils import dict_true_values, file_exists, get_base_url, get_requests_auth, import_app
+from . import events
+from .impl import BaseRunner, SingleThreadRunner, SingleThreadWSGIRunner, ThreadPoolRunner, ThreadPoolWSGIRunner
+
+SUBPROCESS_WAIT_TIMEOUT = 30
+
+
+# pylint: disable=too-many-instance-attributes
+@attr.s(slots=True)
+class ExecutorConfig:
+    schema_uri: str = attr.ib()
+    checks: Iterable[CheckFunction] = attr.ib()
+    hypothesis_options: Dict[str, Any] = attr.ib()
+    loader: Callable = attr.ib(default=loaders.from_uri)
+    base_url: Optional[str] = attr.ib(default=None)
+    endpoint: Optional[Filter] = attr.ib(default=None)
+    method: Optional[Filter] = attr.ib(default=None)
+    tag: Optional[Filter] = attr.ib(default=None)
+    app: Optional[str] = attr.ib(default=None)
+    validate_schema: bool = attr.ib(default=True)
+    workers_num: int = attr.ib(default=1)
+    auth: Optional[RawAuth] = attr.ib(default=None)
+    auth_type: Optional[str] = attr.ib(default=None)
+    headers: Optional[Dict[str, Any]] = attr.ib(default=None)
+    request_timeout: Optional[int] = attr.ib(default=None)
+    seed: Optional[int] = attr.ib(default=None)
+    exit_first: bool = attr.ib(default=False)
+
+
+def execute_in_subprocess(config: ExecutorConfig) -> Generator[events.ExecutionEvent, None, None]:
+    """Execute tests in a subprocess.
+
+    Communication with subprocess is implemented via `multiprocessing.Queue`. This function works as a wrapper around it
+    to provide the same behavior as the in-process counterpart does.
+    """
+    event = None
+    queue: multiprocessing.Queue = multiprocessing.Queue()
+    process = multiprocessing.Process(target=_execute_in_subprocess, args=(queue, config),)
+    process.start()
+    try:
+        while not isinstance(event, events.Finished):
+            try:
+                event = queue.get(timeout=SUBPROCESS_WAIT_TIMEOUT)
+                yield event
+            except Empty as exc:
+                # Something went wrong, e.g. the subprocess was killed without emitting `Interrupted` event.
+                yield events.InternalError.from_exc(exc)
+    finally:
+        process.join()
+
+
+def _execute_in_subprocess(queue: multiprocessing.Queue, config: ExecutorConfig) -> None:
+    """A simple proxy that puts events into a multiprocessing queue."""
+    for event in execute_from_schema(config):
+        queue.put(event)
+
+
+def execute_from_schema(config: ExecutorConfig,) -> Generator[events.ExecutionEvent, None, None]:
+    """Execute tests for the given schema.
+
+    Provides the main testing loop and preparation step.
+    """
+    # pylint: disable=too-many-locals
+    try:
+        app = config.app
+        if app is not None:
+            app = import_app(app)
+        schema = load_schema(
+            config.schema_uri,
+            base_url=config.base_url,
+            loader=config.loader,
+            app=app,
+            validate_schema=config.validate_schema,
+            auth=config.auth,
+            auth_type=config.auth_type,
+            headers=config.headers,
+            endpoint=config.endpoint,
+            method=config.method,
+            tag=config.tag,
+        )
+
+        runner: BaseRunner
+        if config.workers_num > 1:
+            if schema.app:
+                runner = ThreadPoolWSGIRunner(
+                    schema=schema,
+                    checks=config.checks,
+                    hypothesis_settings=config.hypothesis_options,
+                    auth=config.auth,
+                    auth_type=config.auth_type,
+                    headers=config.headers,
+                    seed=config.seed,
+                    workers_num=config.workers_num,
+                    exit_first=config.exit_first,
+                )
+            else:
+                runner = ThreadPoolRunner(
+                    schema=schema,
+                    checks=config.checks,
+                    hypothesis_settings=config.hypothesis_options,
+                    auth=config.auth,
+                    auth_type=config.auth_type,
+                    headers=config.headers,
+                    seed=config.seed,
+                    request_timeout=config.request_timeout,
+                    exit_first=config.exit_first,
+                )
+        else:
+            if schema.app:
+                runner = SingleThreadWSGIRunner(
+                    schema=schema,
+                    checks=config.checks,
+                    hypothesis_settings=config.hypothesis_options,
+                    auth=config.auth,
+                    auth_type=config.auth_type,
+                    headers=config.headers,
+                    seed=config.seed,
+                    exit_first=config.exit_first,
+                )
+            else:
+                runner = SingleThreadRunner(
+                    schema=schema,
+                    checks=config.checks,
+                    hypothesis_settings=config.hypothesis_options,
+                    auth=config.auth,
+                    auth_type=config.auth_type,
+                    headers=config.headers,
+                    seed=config.seed,
+                    request_timeout=config.request_timeout,
+                    exit_first=config.exit_first,
+                )
+        yield from runner.execute()
+    except Exception as exc:
+        yield events.InternalError.from_exc(exc)
+
+
+def load_schema(
+    schema_uri: str,
+    *,
+    base_url: Optional[str] = None,
+    loader: Callable = loaders.from_uri,
+    app: Any = None,
+    validate_schema: bool = True,
+    # Network request parameters
+    auth: Optional[Tuple[str, str]] = None,
+    auth_type: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    # Schema filters
+    endpoint: Optional[Filter] = None,
+    method: Optional[Filter] = None,
+    tag: Optional[Filter] = None,
+) -> BaseSchema:
+    """Load schema via specified loader and parameters."""
+    loader_options = dict_true_values(base_url=base_url, endpoint=endpoint, method=method, tag=tag, app=app)
+
+    if file_exists(schema_uri):
+        loader = loaders.from_path
+    elif app is not None and not urlparse(schema_uri).netloc:
+        # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with
+        # the given app
+        loader = loaders.get_loader_for_app(app)
+    else:
+        loader_options.update(dict_true_values(headers=headers, auth=auth, auth_type=auth_type))
+
+    if "base_url" not in loader_options:
+        loader_options["base_url"] = get_base_url(schema_uri)
+    if loader is loaders.from_uri and loader_options.get("auth"):
+        loader_options["auth"] = get_requests_auth(loader_options["auth"], loader_options.pop("auth_type", None))
+
+    return loader(schema_uri, validate_schema=validate_schema, **loader_options)

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -43,9 +43,7 @@ class BaseRunner:
         """Common logic for all runners."""
         results = TestResultSet()
 
-        initialized = events.Initialized(
-            results=results, schema=self.schema, checks=self.checks, hypothesis_settings=self.hypothesis_settings
-        )
+        initialized = events.Initialized.from_schema(schema=self.schema)
         yield initialized
 
         for event in self._execute(results):
@@ -57,9 +55,7 @@ class BaseRunner:
                 break
             yield event
 
-        yield events.Finished(
-            results=results, schema=self.schema, running_time=time.monotonic() - initialized.start_time
-        )
+        yield events.Finished.from_results(results=results, running_time=time.monotonic() - initialized.start_time)
 
     def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
         raise NotImplementedError
@@ -76,7 +72,7 @@ def run_test(
     """A single test run with all error handling needed."""
     # pylint: disable=too-many-arguments
     result = TestResult(endpoint=endpoint)
-    yield events.BeforeExecution(results=results, schema=schema, endpoint=endpoint)
+    yield events.BeforeExecution.from_endpoint(endpoint=endpoint)
     hypothesis_output: List[str] = []
     try:
         if isinstance(test, InvalidSchema):
@@ -108,7 +104,7 @@ def run_test(
         status = Status.error
         result.add_error(hypothesis.errors.Unsatisfiable("Unable to satisfy schema parameters for this endpoint"))
     except KeyboardInterrupt:
-        yield events.Interrupted(results=results, schema=schema)
+        yield events.Interrupted()
         return
     except Exception as error:
         status = Status.error
@@ -118,9 +114,7 @@ def run_test(
         test, "_hypothesis_internal_use_generated_seed", None
     )
     results.append(result)
-    yield events.AfterExecution(
-        results=results, schema=schema, endpoint=endpoint, status=status, hypothesis_output=hypothesis_output
-    )
+    yield events.AfterExecution(status=status, hypothesis_output=hypothesis_output)
 
 
 def run_checks(case: Case, checks: Iterable[CheckFunction], result: TestResult, response: GenericResponse) -> None:

--- a/src/schemathesis/runner/impl/threadpool.py
+++ b/src/schemathesis/runner/impl/threadpool.py
@@ -120,7 +120,7 @@ class ThreadPoolRunner(BaseRunner):
             stop_workers()
         except KeyboardInterrupt:
             stop_workers()
-            yield events.Interrupted(results=results, schema=self.schema)
+            yield events.Interrupted()
 
     def _get_tasks_queue(self) -> Queue:
         """All endpoints are distributed among all workers via a queue."""

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -1,0 +1,98 @@
+"""Transformation from Schemathesis-specific data structures to ones that can be serialized and sent over network.
+
+They all consist of primitive types and don't have references to schemas, app, etc.
+"""
+# pylint: disable=too-many-instance-attributes
+import logging
+from typing import List, Optional
+
+import attr
+
+from ..models import Case, Check, Status, TestResult
+from ..types import Body, Cookies, FormData, Headers, PathParameters, Query
+from ..utils import format_exception
+
+
+@attr.s(slots=True)
+class SerializedCase:
+    requests_code: str = attr.ib()
+    path_parameters: Optional[PathParameters] = attr.ib(default=None)  # pragma: no mutate
+    headers: Optional[Headers] = attr.ib(default=None)  # pragma: no mutate
+    cookies: Optional[Cookies] = attr.ib(default=None)  # pragma: no mutate
+    query: Optional[Query] = attr.ib(default=None)  # pragma: no mutate
+    body: Optional[Body] = attr.ib(default=None)  # pragma: no mutate
+    form_data: Optional[FormData] = attr.ib(default=None)  # pragma: no mutate
+
+    @classmethod
+    def from_case(cls, case: Case) -> "SerializedCase":
+        return cls(
+            path_parameters=case.path_parameters,
+            headers=case.headers,
+            cookies=case.cookies,
+            query=case.query,
+            body=case.body,
+            form_data=case.form_data,
+            requests_code=case.get_code_to_reproduce(),
+        )
+
+
+@attr.s(slots=True)
+class SerializedCheck:
+    name: str = attr.ib()  # pragma: no mutate
+    value: Status = attr.ib()  # pragma: no mutate
+    example: Optional[SerializedCase] = attr.ib(default=None)  # pragma: no mutate
+    message: Optional[str] = attr.ib(default=None)  # pragma: no mutate
+
+    @classmethod
+    def from_check(cls, check: Check) -> "SerializedCheck":
+        return SerializedCheck(
+            name=check.name,
+            value=check.value,
+            example=SerializedCase.from_case(check.example) if check.example else None,
+            message=check.message,
+        )
+
+
+@attr.s(slots=True)
+class SerializedError:
+    exception: str = attr.ib()
+    exception_with_traceback: str = attr.ib()
+    example: Optional[SerializedCase] = attr.ib()
+
+    @classmethod
+    def from_error(cls, exception: Exception, case: Optional[Case]) -> "SerializedError":
+        return cls(
+            exception=format_exception(exception),
+            exception_with_traceback=format_exception(exception, True),
+            example=SerializedCase.from_case(case) if case else None,
+        )
+
+
+@attr.s(slots=True)
+class SerializedTestResult:
+    method: str = attr.ib()
+    path: str = attr.ib()
+    has_failures: bool = attr.ib()
+    has_errors: bool = attr.ib()
+    has_logs: bool = attr.ib()
+    is_errored: bool = attr.ib()
+    seed: Optional[int] = attr.ib()
+    checks: List[SerializedCheck] = attr.ib()
+    logs: List[str] = attr.ib()
+    errors: List[SerializedError] = attr.ib()
+
+    @classmethod
+    def from_test_result(cls, result: TestResult) -> "SerializedTestResult":
+        formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+        return SerializedTestResult(
+            method=result.endpoint.method,
+            path=result.endpoint.path,
+            has_failures=result.has_failures,
+            has_errors=result.has_errors,
+            has_logs=result.has_logs,
+            is_errored=result.is_errored,
+            seed=result.seed,
+            checks=[SerializedCheck.from_check(check) for check in result.checks],
+            logs=[formatter.format(record) for record in result.logs],
+            errors=[SerializedError.from_error(*error) for error in result.errors],
+        )

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,6 +1,7 @@
 import cgi
 import pathlib
 import re
+import sys
 import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union
@@ -162,3 +163,13 @@ def get_requests_auth(auth: Optional[RawAuth], auth_type: Optional[str]) -> Opti
 
 
 GenericResponse = Union[requests.Response, WSGIResponse]  # pragma: no mutate
+
+
+def import_app(path: str) -> Any:
+    """Import an application from a string."""
+    path, name = (re.split(r":(?![\\/])", path, 1) + [None])[:2]  # type: ignore
+    __import__(path)
+    # accessing the module from sys.modules returns a proper module, while `__import__`
+    # may return a parent module (system dependent)
+    module = sys.modules[path]
+    return getattr(module, name)

--- a/test/runner/test_events.py
+++ b/test/runner/test_events.py
@@ -1,0 +1,10 @@
+from schemathesis.runner import events
+
+
+def test_unknown_exception():
+    try:
+        1 / 0
+    except Exception as exc:
+        event = events.InternalError.from_exc(exc)
+        assert event.message == "An internal error happened during a test run"
+        assert event.exception.strip() == "ZeroDivisionError: division by zero"

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -17,12 +17,15 @@ from schemathesis.checks import (
 )
 from schemathesis.constants import __version__
 from schemathesis.models import Status
-from schemathesis.runner import events, get_base_url, get_requests_auth, prepare
+from schemathesis.runner import RunnerExecutionMode, events, prepare
 from schemathesis.runner.impl.core import get_wsgi_auth
+from schemathesis.utils import get_base_url, get_requests_auth
 
 
 def execute(schema_uri, checks=DEFAULT_CHECKS, loader=from_uri, **options) -> events.Finished:
-    generator = prepare(schema_uri=schema_uri, checks=checks, loader=loader, **options)
+    generator = prepare(
+        schema_uri=schema_uri, execution_mode=RunnerExecutionMode.inprocess, checks=checks, loader=loader, **options
+    )
     all_events = list(generator)
     return all_events[-1]
 
@@ -86,7 +89,7 @@ def args(request, mocker):
         app = request.getfixturevalue("flask_app")
         app_path = request.getfixturevalue("loadable_flask_app")
         # To have simpler tests it is easier to reuse already imported application for inspection
-        mocker.patch("schemathesis.runner.import_app", return_value=app)
+        mocker.patch("schemathesis.runner.executors.import_app", return_value=app)
         kwargs = {"schema_uri": "/swagger.yaml", "app": app_path, "loader": from_wsgi}
     return app, kwargs
 


### PR DESCRIPTION
The goal is to be able to run `runner` in a subprocess while still having the same interface with an event generator. Few things should be done to achieve it:

- [x] Make all events serializable with `pickle`
- [x] Make all runner input values also serializable with `pickle` (`app` is not)
- [x] Connect a subprocess with the main one via `multiprocessing.Queue`
- [x] Parametrize all tests to make sure, that all features work in both modes

**Update**:
Serialization of all small bits of events is quite annoying :( Tracebacks, exceptions, apps, hooks need special care. Most of the logic works out of the box, though. Maybe as the first step, it will be better to make events independent from `schema`, `endpoint`, etc and store what is needed right there, without using some logic from `BaseSchema` and other classes, store serialized tracebacks, errors as strings, etc so nothing complex is sent between parent / child processes. It probably will help in the future, e.g. it will be easier to implement the usage of CLI to control remote nodes:
- [x] Remove all usage of `ExecutionEvent.schema` in CLI, use static data;
- [x] The same for `endpoint`