### PR TITLE
refactor: Make `runner` events into serializable static objects

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,19 @@ Changelog
 `Unreleased`_
 -------------
 
+Changed
+~~~~~~~
+
+- App loading in ``runner``. Now it accepts application as an importable string, rather than an instance. It is done
+  to make it possible to execute runner in a subprocess. Otherwise apps can't be easily serialized and transferred into
+  another process.
+- Runner events structure. All data in events is static from now, there are no references to ``BaseSchema``, ``Endpoint`` or
+  similar objects that may calculate data dynamically. This is done to make events serializable and not tied to Python
+  object which decouples any ``runner`` consumer from implementation details and will help make ``runner`` usable in
+  more cases (e.g. web application), since events can be serialized to JSON and used in any environment.
+  Another related change is that Python exceptions are not propagated anymore - they are replaced with ``InternalError``
+  event that should be handled accordingly.
+
 `1.0.5`_ - 2020-04-03
 ---------------------
 

--- a/src/schemathesis/cli/context.py
+++ b/src/schemathesis/cli/context.py
@@ -1,8 +1,11 @@
+# pylint: disable=too-many-instance-attributes
 import os
 import shutil
-from typing import List
+from typing import List, Optional
 
 import attr
+
+from ..runner.serialization import SerializedTestResult
 
 
 @attr.s(slots=True)  # pragma: no mutate
@@ -13,5 +16,8 @@ class ExecutionContext:
     workers_num: int = attr.ib(default=1)  # pragma: no mutate
     show_errors_tracebacks: bool = attr.ib(default=False)  # pragma: no mutate
     endpoints_processed: int = attr.ib(default=0)  # pragma: no mutate
+    # It is set in runtime, from a `Initialized` event
+    endpoints_count: Optional[int] = attr.ib(default=None)  # pragma: no mutate
     current_line_length: int = attr.ib(default=0)  # pragma: no mutate
     terminal_size: os.terminal_size = attr.ib(factory=shutil.get_terminal_size)  # pragma: no mutate
+    results: List[SerializedTestResult] = attr.ib(factory=list)  # pragma: no mutate

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -1,18 +1,16 @@
-import logging
 import os
 import platform
 import shutil
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import click
-from attr import Attribute
 from hypothesis import settings
 
 from ..._compat import metadata
 from ...constants import __version__
-from ...models import Case, Check, Status, TestResult, TestResultSet
+from ...models import Status
 from ...runner import events
-from .. import utils
+from ...runner.serialization import SerializedCase, SerializedCheck, SerializedTestResult
 from ..context import ExecutionContext
 
 
@@ -27,8 +25,8 @@ def display_section_name(title: str, separator: str = "=", **kwargs: Any) -> Non
     click.secho(message, **kwargs)
 
 
-def display_subsection(result: TestResult, color: Optional[str] = "red") -> None:
-    section_name = f"{result.endpoint.method}: {result.endpoint.path}"
+def display_subsection(result: SerializedTestResult, color: Optional[str] = "red") -> None:
+    section_name = f"{result.method}: {result.path}"
     display_section_name(section_name, "_", fg=color)
 
 
@@ -50,7 +48,8 @@ def display_execution_result(context: ExecutionContext, event: events.AfterExecu
 def display_percentage(context: ExecutionContext, event: events.AfterExecution) -> None:
     """Add the current progress in % to the right side of the current line."""
     padding = 1
-    current_percentage = get_percentage(context.endpoints_processed, event.schema.endpoints_count)
+    endpoints_count = cast(int, context.endpoints_count)  # is already initialized via `Initialized` event
+    current_percentage = get_percentage(context.endpoints_processed, endpoints_count)
     styled = click.style(current_percentage, fg="cyan")
     # Total length of the message so it will fill to the right border of the terminal minus padding
     length = get_terminal_width() - context.current_line_length + len(styled) - len(current_percentage) - padding
@@ -64,29 +63,29 @@ def display_summary(event: events.Finished) -> None:
     raise click.exceptions.Exit(status_code)
 
 
-def get_summary_message_parts(results: TestResultSet) -> List[str]:
+def get_summary_message_parts(event: events.Finished) -> List[str]:
     parts = []
-    passed = results.passed_count
+    passed = event.passed_count
     if passed:
         parts.append(f"{passed} passed")
-    failed = results.failed_count
+    failed = event.failed_count
     if failed:
         parts.append(f"{failed} failed")
-    errored = results.errored_count
+    errored = event.errored_count
     if errored:
         parts.append(f"{errored} errored")
     return parts
 
 
 def get_summary_output(event: events.Finished) -> Tuple[str, str, int]:
-    parts = get_summary_message_parts(event.results)
+    parts = get_summary_message_parts(event)
     if not parts:
         message = "Empty test suite"
         color = "yellow"
         status_code = 0
     else:
         message = f'{", ".join(parts)} in {event.running_time:.2f}s'
-        if event.results.has_failures or event.results.has_errors:
+        if event.has_failures or event.has_errors:
             color = "red"
             status_code = 1
         else:
@@ -103,13 +102,13 @@ def display_hypothesis_output(hypothesis_output: List[str]) -> None:
         click.secho(output, fg="red")
 
 
-def display_errors(context: ExecutionContext, results: TestResultSet) -> None:
+def display_errors(context: ExecutionContext, event: events.Finished) -> None:
     """Display all errors in the test run."""
-    if not results.has_errors:
+    if not event.has_errors:
         return
 
     display_section_name("ERRORS")
-    for result in results:
+    for result in context.results:
         if not result.has_errors:
             continue
         display_single_error(context, result)
@@ -119,20 +118,23 @@ def display_errors(context: ExecutionContext, results: TestResultSet) -> None:
         )
 
 
-def display_single_error(context: ExecutionContext, result: TestResult) -> None:
+def display_single_error(context: ExecutionContext, result: SerializedTestResult) -> None:
     display_subsection(result)
-    for error, example in result.errors:
-        message = utils.format_exception(error, include_traceback=context.show_errors_tracebacks)
+    for error in result.errors:
+        if context.show_errors_tracebacks:
+            message = error.exception_with_traceback
+        else:
+            message = error.exception
         click.secho(message, fg="red")
-        if example is not None:
-            display_example(example, seed=result.seed)
+        if error.example is not None:
+            display_example(error.example, seed=result.seed)
 
 
-def display_failures(results: TestResultSet) -> None:
+def display_failures(context: ExecutionContext, event: events.Finished) -> None:
     """Display all failures in the test run."""
-    if not results.has_failures:
+    if not event.has_failures:
         return
-    relevant_results = [result for result in results if not result.is_errored]
+    relevant_results = [result for result in context.results if not result.is_errored]
     if not relevant_results:
         return
     display_section_name("FAILURES")
@@ -142,7 +144,7 @@ def display_failures(results: TestResultSet) -> None:
         display_failures_for_single_test(result)
 
 
-def display_failures_for_single_test(result: TestResult) -> None:
+def display_failures_for_single_test(result: SerializedTestResult) -> None:
     """Display a failure for a single method / endpoint."""
     display_subsection(result)
     checks = _get_unique_failures(result.checks)
@@ -152,14 +154,14 @@ def display_failures_for_single_test(result: TestResult) -> None:
             message = f"{idx}. {check.message}"
         else:
             message = None
-        example = cast(Case, check.example)  # filtered in `_get_unique_failures`
+        example = cast(SerializedCase, check.example)  # filtered in `_get_unique_failures`
         display_example(example, check.name, message, result.seed)
         # Display every time except the last check
         if idx != len(checks):
             click.echo("\n")
 
 
-def _get_unique_failures(checks: List[Check]) -> List[Check]:
+def _get_unique_failures(checks: List[SerializedCheck]) -> List[SerializedCheck]:
     """Return only unique checks that should be displayed in the output."""
     seen: Set[Tuple[str, Optional[str]]] = set()
     unique_checks = []
@@ -172,15 +174,14 @@ def _get_unique_failures(checks: List[Check]) -> List[Check]:
 
 
 def display_example(
-    case: Case, check_name: Optional[str] = None, message: Optional[str] = None, seed: Optional[int] = None
+    case: SerializedCase, check_name: Optional[str] = None, message: Optional[str] = None, seed: Optional[int] = None
 ) -> None:
     if message is not None:
         click.secho(message, fg="red")
         click.echo()
     output = {
-        make_verbose_name(attribute): getattr(case, attribute.name)
-        for attribute in Case.__attrs_attrs__  # type: ignore
-        if attribute.name not in ("path", "method", "base_url", "app", "endpoint")
+        make_verbose_name(attribute): getattr(case, attribute)
+        for attribute in ("path_parameters", "headers", "cookies", "query", "body", "form_data")
     }
     max_length = max(map(len, output))
     template = f"{{:<{max_length}}} : {{}}"
@@ -190,39 +191,37 @@ def display_example(
         if (key == "Body" and value is not None) or value not in (None, {}):
             click.secho(template.format(key, value), fg="red")
     click.echo()
-    click.secho(f"Run this Python code to reproduce this failure: \n\n    {case.get_code_to_reproduce()}", fg="red")
+    click.secho(f"Run this Python code to reproduce this failure: \n\n    {case.requests_code}", fg="red")
     if seed is not None:
         click.secho(f"\nOr add this option to your command line parameters: --hypothesis-seed={seed}", fg="red")
 
 
-def make_verbose_name(attribute: Attribute) -> str:
-    return attribute.name.capitalize().replace("_", " ")
+def make_verbose_name(attribute: str) -> str:
+    return attribute.capitalize().replace("_", " ")
 
 
-def display_application_logs(statistic: TestResultSet) -> None:
+def display_application_logs(context: ExecutionContext, event: events.Finished) -> None:
     """Print logs captured during the application run."""
-    if not statistic.has_logs:
+    if not event.has_logs:
         return
     display_section_name("APPLICATION LOGS")
-    formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
-    for result in statistic:
+    for result in context.results:
         if not result.has_logs:
             continue
-        display_single_log(result, formatter)
+        display_single_log(result)
 
 
-def display_single_log(result: TestResult, formatter: logging.Formatter) -> None:
+def display_single_log(result: SerializedTestResult) -> None:
     display_subsection(result, None)
-    formatted = [formatter.format(record) for record in result.logs]
-    click.echo("\n\n".join(formatted))
+    click.echo("\n\n".join(result.logs))
 
 
-def display_statistic(statistic: TestResultSet) -> None:
+def display_statistic(event: events.Finished) -> None:
     """Format and print statistic collected by :obj:`models.TestResult`."""
     display_section_name("SUMMARY")
     click.echo()
-    total = statistic.total
-    if statistic.is_empty or not total:
+    total = event.total
+    if event.is_empty or not total:
         click.secho("No checks were performed.", bold=True)
         return
 
@@ -254,8 +253,19 @@ def display_check_result(check_name: str, results: Dict[Union[str, Status], int]
     )
 
 
+def display_internal_error(context: ExecutionContext, event: events.InternalError) -> None:
+    click.secho(event.message, fg="red")
+    if event.exception:
+        if context.show_errors_tracebacks:
+            message = event.exception_with_traceback
+        else:
+            message = event.exception
+        click.secho(f"Error: {message}", fg="red")
+
+
 def handle_initialized(context: ExecutionContext, event: events.Initialized) -> None:
     """Display information about the test session."""
+    context.endpoints_count = event.endpoints_count
     display_section_name("Schemathesis test session starts")
     versions = (
         f"platform {platform.system()} -- "
@@ -271,20 +281,20 @@ def handle_initialized(context: ExecutionContext, event: events.Initialized) -> 
         f"hypothesis profile '{settings._current_profile}' "  # type: ignore
         f"-> {settings.get_profile(settings._current_profile).show_changed()}"
     )
-    if event.schema.location is not None:
-        click.echo(f"Schema location: {event.schema.location}")
-    if event.schema.base_url is not None:
-        click.echo(f"Base URL: {event.schema.base_url}")
-    click.echo(f"Specification version: {event.schema.verbose_name}")
+    if event.location is not None:
+        click.echo(f"Schema location: {event.location}")
+    if event.base_url is not None:
+        click.echo(f"Base URL: {event.base_url}")
+    click.echo(f"Specification version: {event.specification_name}")
     click.echo(f"Workers: {context.workers_num}")
-    click.secho(f"collected endpoints: {event.schema.endpoints_count}", bold=True)
-    if event.schema.endpoints_count >= 1:
+    click.secho(f"collected endpoints: {event.endpoints_count}", bold=True)
+    if event.endpoints_count >= 1:
         click.echo()
 
 
 def handle_before_execution(context: ExecutionContext, event: events.BeforeExecution) -> None:
     """Display what method / endpoint will be tested next."""
-    message = f"{event.endpoint.method} {event.endpoint.path} "
+    message = f"{event.method} {event.path} "
     context.current_line_length = len(message)
     click.echo(message, nl=False)
 
@@ -292,6 +302,7 @@ def handle_before_execution(context: ExecutionContext, event: events.BeforeExecu
 def handle_after_execution(context: ExecutionContext, event: events.AfterExecution) -> None:
     """Display the execution result + current progress at the same line with the method / endpoint names."""
     context.endpoints_processed += 1
+    context.results.append(event.result)
     display_execution_result(context, event)
     display_percentage(context, event)
 
@@ -300,10 +311,10 @@ def handle_finished(context: ExecutionContext, event: events.Finished) -> None:
     """Show the outcome of the whole testing session."""
     click.echo()
     display_hypothesis_output(context.hypothesis_output)
-    display_errors(context, event.results)
-    display_failures(event.results)
-    display_application_logs(event.results)
-    display_statistic(event.results)
+    display_errors(context, event)
+    display_failures(context, event)
+    display_application_logs(context, event)
+    display_statistic(event)
     click.echo()
     display_summary(event)
 
@@ -311,6 +322,11 @@ def handle_finished(context: ExecutionContext, event: events.Finished) -> None:
 def handle_interrupted(context: ExecutionContext, event: events.Interrupted) -> None:
     click.echo()
     display_section_name("KeyboardInterrupt", "!", bold=False)
+
+
+def handle_internal_error(context: ExecutionContext, event: events.InternalError) -> None:
+    display_internal_error(context, event)
+    raise click.Abort
 
 
 def handle_event(context: ExecutionContext, event: events.ExecutionEvent) -> None:
@@ -326,3 +342,5 @@ def handle_event(context: ExecutionContext, event: events.ExecutionEvent) -> Non
         handle_finished(context, event)
     if isinstance(event, events.Interrupted):
         handle_interrupted(context, event)
+    if isinstance(event, events.InternalError):
+        handle_internal_error(context, event)

--- a/src/schemathesis/cli/output/short.py
+++ b/src/schemathesis/cli/output/short.py
@@ -7,8 +7,10 @@ from . import default
 
 def handle_after_execution(context: ExecutionContext, event: events.AfterExecution) -> None:
     context.endpoints_processed += 1
+    context.results.append(event.result)
+    context.hypothesis_output.extend(event.hypothesis_output)
     default.display_execution_result(context, event)
-    if context.endpoints_processed == event.schema.endpoints_count:
+    if context.endpoints_processed == context.endpoints_count:
         click.echo()
 
 
@@ -20,9 +22,10 @@ def handle_event(context: ExecutionContext, event: events.ExecutionEvent) -> Non
     if isinstance(event, events.Initialized):
         default.handle_initialized(context, event)
     if isinstance(event, events.AfterExecution):
-        context.hypothesis_output.extend(event.hypothesis_output)
         handle_after_execution(context, event)
     if isinstance(event, events.Finished):
         default.handle_finished(context, event)
     if isinstance(event, events.Interrupted):
         default.handle_interrupted(context, event)
+    if isinstance(event, events.InternalError):
+        default.handle_internal_error(context, event)

--- a/src/schemathesis/runner/impl/threadpool.py
+++ b/src/schemathesis/runner/impl/threadpool.py
@@ -120,7 +120,7 @@ class ThreadPoolRunner(BaseRunner):
             stop_workers()
         except KeyboardInterrupt:
             stop_workers()
-            yield events.Interrupted(results=results, schema=self.schema)
+            yield events.Interrupted()
 
     def _get_tasks_queue(self) -> Queue:
         """All endpoints are distributed among all workers via a queue."""

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -1,0 +1,98 @@
+"""Transformation from Schemathesis-specific data structures to ones that can be serialized and sent over network.
+
+They all consist of primitive types and don't have references to schemas, app, etc.
+"""
+# pylint: disable=too-many-instance-attributes
+import logging
+from typing import List, Optional
+
+import attr
+
+from ..models import Case, Check, Status, TestResult
+from ..types import Body, Cookies, FormData, Headers, PathParameters, Query
+from ..utils import format_exception
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SerializedCase:
+    requests_code: str = attr.ib()  # pragma: no mutate
+    path_parameters: Optional[PathParameters] = attr.ib(default=None)  # pragma: no mutate
+    headers: Optional[Headers] = attr.ib(default=None)  # pragma: no mutate
+    cookies: Optional[Cookies] = attr.ib(default=None)  # pragma: no mutate
+    query: Optional[Query] = attr.ib(default=None)  # pragma: no mutate
+    body: Optional[Body] = attr.ib(default=None)  # pragma: no mutate
+    form_data: Optional[FormData] = attr.ib(default=None)  # pragma: no mutate
+
+    @classmethod
+    def from_case(cls, case: Case) -> "SerializedCase":
+        return cls(
+            path_parameters=case.path_parameters,
+            headers=case.headers,
+            cookies=case.cookies,
+            query=case.query,
+            body=case.body,
+            form_data=case.form_data,
+            requests_code=case.get_code_to_reproduce(),
+        )
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SerializedCheck:
+    name: str = attr.ib()  # pragma: no mutate
+    value: Status = attr.ib()  # pragma: no mutate
+    example: Optional[SerializedCase] = attr.ib(default=None)  # pragma: no mutate
+    message: Optional[str] = attr.ib(default=None)  # pragma: no mutate
+
+    @classmethod
+    def from_check(cls, check: Check) -> "SerializedCheck":
+        return SerializedCheck(
+            name=check.name,
+            value=check.value,
+            example=SerializedCase.from_case(check.example) if check.example else None,
+            message=check.message,
+        )
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SerializedError:
+    exception: str = attr.ib()  # pragma: no mutate
+    exception_with_traceback: str = attr.ib()  # pragma: no mutate
+    example: Optional[SerializedCase] = attr.ib()  # pragma: no mutate
+
+    @classmethod
+    def from_error(cls, exception: Exception, case: Optional[Case]) -> "SerializedError":
+        return cls(
+            exception=format_exception(exception),
+            exception_with_traceback=format_exception(exception, True),
+            example=SerializedCase.from_case(case) if case else None,
+        )
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SerializedTestResult:
+    method: str = attr.ib()  # pragma: no mutate
+    path: str = attr.ib()  # pragma: no mutate
+    has_failures: bool = attr.ib()  # pragma: no mutate
+    has_errors: bool = attr.ib()  # pragma: no mutate
+    has_logs: bool = attr.ib()  # pragma: no mutate
+    is_errored: bool = attr.ib()  # pragma: no mutate
+    seed: Optional[int] = attr.ib()  # pragma: no mutate
+    checks: List[SerializedCheck] = attr.ib()  # pragma: no mutate
+    logs: List[str] = attr.ib()  # pragma: no mutate
+    errors: List[SerializedError] = attr.ib()  # pragma: no mutate
+
+    @classmethod
+    def from_test_result(cls, result: TestResult) -> "SerializedTestResult":
+        formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+        return SerializedTestResult(
+            method=result.endpoint.method,
+            path=result.endpoint.path,
+            has_failures=result.has_failures,
+            has_errors=result.has_errors,
+            has_logs=result.has_logs,
+            is_errored=result.is_errored,
+            seed=result.seed,
+            checks=[SerializedCheck.from_check(check) for check in result.checks],
+            logs=[formatter.format(record) for record in result.logs],
+            errors=[SerializedError.from_error(*error) for error in result.errors],
+        )

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -1,6 +1,7 @@
 import cgi
 import pathlib
 import re
+import sys
 import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union
@@ -162,3 +163,13 @@ def get_requests_auth(auth: Optional[RawAuth], auth_type: Optional[str]) -> Opti
 
 
 GenericResponse = Union[requests.Response, WSGIResponse]  # pragma: no mutate
+
+
+def import_app(path: str) -> Any:
+    """Import an application from a string."""
+    path, name = (re.split(r":(?![\\/])", path, 1) + [None])[:2]  # type: ignore
+    __import__(path)
+    # accessing the module from sys.modules returns a proper module, while `__import__`
+    # may return a parent module (system dependent)
+    module = sys.modules[path]
+    return getattr(module, name)

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 import click
-import hypothesis
 import pytest
 from hypothesis.reporting import report
 
@@ -10,6 +9,9 @@ import schemathesis
 import schemathesis.cli.context
 from schemathesis import models, runner, utils
 from schemathesis.cli.output import default
+from schemathesis.cli.output.default import display_internal_error
+from schemathesis.runner.events import Finished, InternalError
+from schemathesis.runner.serialization import SerializedTestResult
 
 from ...utils import strip_style_win32
 
@@ -23,7 +25,7 @@ def click_context():
 
 @pytest.fixture()
 def execution_context():
-    return schemathesis.cli.context.ExecutionContext([])
+    return schemathesis.cli.context.ExecutionContext([], endpoints_count=1)
 
 
 @pytest.fixture
@@ -39,8 +41,8 @@ def results_set(endpoint):
 
 @pytest.fixture()
 def after_execution(results_set, endpoint, swagger_20):
-    return runner.events.AfterExecution(
-        results=results_set, schema=swagger_20, endpoint=endpoint, status=models.Status.success
+    return runner.events.AfterExecution.from_result(
+        result=results_set.results[0], status=models.Status.success, hypothesis_output=[]
     )
 
 
@@ -65,9 +67,7 @@ def test_display_section_name(capsys, title, separator, printed, expected):
 
 def test_handle_initialized(capsys, execution_context, results_set, swagger_20):
     # Given Initialized event
-    event = runner.events.Initialized(
-        results=results_set, schema=swagger_20, checks=(), hypothesis_settings=hypothesis.settings()
-    )
+    event = runner.events.Initialized.from_schema(schema=swagger_20)
     # When this even is handled
     default.handle_initialized(execution_context, event)
     out = capsys.readouterr().out
@@ -92,8 +92,9 @@ def test_display_statistic(capsys, swagger_20, endpoint):
         endpoint, [success, success, success, failure, failure, models.Check("different_check", models.Status.success)]
     )
     results = models.TestResultSet([single_test_statistic])
+    event = Finished.from_results(results, running_time=1.0)
     # When test results are displayed
-    default.display_statistic(results)
+    default.display_statistic(event)
 
     lines = [line for line in capsys.readouterr().out.split("\n") if line]
     failed = strip_style_win32(click.style("FAILED", bold=True, fg="red"))
@@ -164,7 +165,7 @@ def test_display_single_failure(capsys, swagger_20, endpoint, body):
         endpoint, [success, success, success, failure, failure, models.Check("different_check", models.Status.success)]
     )
     # When this failure is displayed
-    default.display_failures_for_single_test(test_statistic)
+    default.display_failures_for_single_test(SerializedTestResult.from_test_result(test_statistic))
     out = capsys.readouterr().out
     lines = out.split("\n")
     # Then the endpoint name is displayed as a subsection
@@ -228,7 +229,7 @@ def test_display_single_error(capsys, swagger_20, endpoint, execution_context, s
     result.add_error(exception)
     # When the related test result is displayed
     execution_context.show_errors_tracebacks = show_errors_tracebacks
-    default.display_single_error(execution_context, result)
+    default.display_single_error(execution_context, SerializedTestResult.from_test_result(result))
     lines = capsys.readouterr().out.strip().split("\n")
     # Then it should be correctly formatted and displayed in red color
     if sys.version_info <= (3, 8):
@@ -246,14 +247,16 @@ def test_display_single_error(capsys, swagger_20, endpoint, execution_context, s
         assert "\n".join(lines[1:6]) == strip_style_win32(click.style(expected, fg="red")).rstrip("\n")
 
 
-def test_display_failures(swagger_20, capsys, results_set):
+def test_display_failures(swagger_20, capsys, execution_context, results_set):
     # Given two test results - success and failure
     endpoint = models.Endpoint("/api/failure", "GET", {}, base_url="http://127.0.0.1:8080", schema=swagger_20)
     failure = models.TestResult(endpoint)
     failure.add_failure("test", models.Case(endpoint), "Message")
+    execution_context.results.append(SerializedTestResult.from_test_result(failure))
     results_set.append(failure)
+    event = Finished.from_results(results_set, 1.0)
     # When the failures are displayed
-    default.display_failures(results_set)
+    default.display_failures(execution_context, event)
     out = capsys.readouterr().out.strip()
     # Then section title is displayed
     assert " FAILURES " in out
@@ -273,9 +276,11 @@ def test_display_errors(swagger_20, capsys, results_set, execution_context, show
     error = models.TestResult(endpoint, seed=123)
     error.add_error(ConnectionError("Connection refused!"), models.Case(endpoint, query={"a": 1}))
     results_set.append(error)
+    execution_context.results.append(SerializedTestResult.from_test_result(error))
+    event = Finished.from_results(results_set, 1.0)
     # When the errors are displayed
     execution_context.show_errors_tracebacks = show_errors_tracebacks
-    default.display_errors(execution_context, results_set)
+    default.display_errors(execution_context, event)
     out = capsys.readouterr().out.strip()
     # Then section title is displayed
     assert " ERRORS " in out
@@ -293,16 +298,27 @@ def test_display_errors(swagger_20, capsys, results_set, execution_context, show
     assert "Or add this option to your command line parameters: --hypothesis-seed=123" in out
 
 
-@pytest.mark.parametrize(
-    "attribute, expected", ((models.Case.__attrs_attrs__[3], "Cookies"), (models.Case.__attrs_attrs__[4], "Query"))
-)
+@pytest.mark.parametrize("show_errors_tracebacks", (True, False))
+def test_display_internal_error(capsys, execution_context, show_errors_tracebacks):
+    execution_context.show_errors_tracebacks = show_errors_tracebacks
+    try:
+        1 / 0
+    except ArithmeticError as exc:
+        event = InternalError.from_exc(exc)
+        display_internal_error(execution_context, event)
+        out = capsys.readouterr().out.strip()
+        assert ("Traceback (most recent call last):" in out) is show_errors_tracebacks
+        assert "ZeroDivisionError: division by zero" in out
+
+
+@pytest.mark.parametrize("attribute, expected", (("cookies", "Cookies"), ("path_parameters", "Path parameters")))
 def test_make_verbose_name(attribute, expected):
     assert default.make_verbose_name(attribute) == expected
 
 
 def test_display_summary(capsys, results_set, swagger_20):
     # Given the Finished event
-    event = runner.events.Finished(results=results_set, schema=swagger_20, running_time=1.257)
+    event = runner.events.Finished.from_results(results=results_set, running_time=1.257)
     # When `display_summary` is called
     with pytest.raises(click.exceptions.Exit):
         default.display_summary(event)

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -126,7 +126,7 @@ def test_commands_version(cli):
             ("run", "http://127.0.0.1", "--header=test:тест"),
             "Error: Invalid value for '--header' / '-H': Header value should be latin-1 encodable",
         ),
-        (("run", "//test",), "Error: Invalid SCHEMA, must be a valid URL or file path."),
+        (("run", "//test"), "Error: Invalid SCHEMA, must be a valid URL or file path."),
     ),
 )
 def test_commands_run_errors(cli, args, error):
@@ -215,13 +215,12 @@ SCHEMA_URI = "https://example.com/swagger.json"
 @pytest.mark.parametrize(
     "args, expected",
     (
-        ([SCHEMA_URI], {}),
-        ([SCHEMA_URI, "--exitfirst"], {"exit_first": True},),
-        ([SCHEMA_URI, "--workers=2"], {"workers_num": 2},),
-        ([SCHEMA_URI, "--hypothesis-seed=123"], {"seed": 123},),
+        ([], {}),
+        (["--exitfirst"], {"exit_first": True}),
+        (["--workers=2"], {"workers_num": 2}),
+        (["--hypothesis-seed=123"], {"seed": 123}),
         (
             [
-                SCHEMA_URI,
                 "--hypothesis-deadline=1000",
                 "--hypothesis-derandomize",
                 "--hypothesis-max-examples=1000",
@@ -242,7 +241,7 @@ SCHEMA_URI = "https://example.com/swagger.json"
                 },
             },
         ),
-        ([SCHEMA_URI, "--hypothesis-deadline=None"], {"hypothesis_options": {"deadline": None}},),
+        (["--hypothesis-deadline=None"], {"hypothesis_options": {"deadline": None}}),
     ),
 )
 def test_execute_arguments(cli, mocker, simple_schema, args, expected):
@@ -252,9 +251,18 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
     mocker.patch("schemathesis.loaders.requests.get", return_value=response)
     execute = mocker.patch("schemathesis.runner.execute_from_schema", autospec=True)
 
-    result = cli.run(*args)
+    result = cli.run(SCHEMA_URI, *args)
 
     expected = {
+        "app": None,
+        "base_url": None,
+        "checks": DEFAULT_CHECKS,
+        "endpoint": (),
+        "method": (),
+        "tag": (),
+        "schema_uri": SCHEMA_URI,
+        "validate_schema": True,
+        "loader": from_uri,
         "hypothesis_options": {},
         "workers_num": 1,
         "exit_first": False,
@@ -268,32 +276,28 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
 
     assert result.exit_code == ExitCode.OK
     assert execute.call_args[1] == expected
-    assert execute.call_args[0][1] == DEFAULT_CHECKS
 
 
 @pytest.mark.parametrize(
     "args, expected",
     (
-        ([SCHEMA_URI, "--auth=test:test"], {"auth": ("test", "test"), "auth_type": "basic"}),
-        ([SCHEMA_URI, "--auth=test:test", "--auth-type=digest"], {"auth": ("test", "test"), "auth_type": "digest"}),
-        ([SCHEMA_URI, "--auth=test:test", "--auth-type=DIGEST"], {"auth": ("test", "test"), "auth_type": "digest"}),
-        ([SCHEMA_URI, "--header=Authorization:Bearer 123"], {"headers": {"Authorization": "Bearer 123"}}),
-        ([SCHEMA_URI, "--header=Authorization:  Bearer 123 "], {"headers": {"Authorization": "Bearer 123 "}}),
-        ([SCHEMA_URI, "--method=POST", "--method", "GET"], {"method": ("POST", "GET")}),
-        (
-            [SCHEMA_URI, "--method=POST", "--auth=test:test"],
-            {"auth": ("test", "test"), "auth_type": "basic", "method": ("POST",)},
-        ),
-        ([SCHEMA_URI, "--endpoint=users"], {"endpoint": ("users",)}),
-        ([SCHEMA_URI, "--tag=foo"], {"tag": ("foo",)}),
-        ([SCHEMA_URI, "--base-url=https://example.com/api/v1test"], {"base_url": "https://example.com/api/v1test"}),
+        (["--auth=test:test"], {"auth": ("test", "test"), "auth_type": "basic"}),
+        (["--auth=test:test", "--auth-type=digest"], {"auth": ("test", "test"), "auth_type": "digest"}),
+        (["--auth=test:test", "--auth-type=DIGEST"], {"auth": ("test", "test"), "auth_type": "digest"}),
+        (["--header=Authorization:Bearer 123"], {"headers": {"Authorization": "Bearer 123"}}),
+        (["--header=Authorization:  Bearer 123 "], {"headers": {"Authorization": "Bearer 123 "}}),
+        (["--method=POST", "--method", "GET"], {"method": ("POST", "GET")}),
+        (["--method=POST", "--auth=test:test"], {"auth": ("test", "test"), "auth_type": "basic", "method": ("POST",)},),
+        (["--endpoint=users"], {"endpoint": ("users",)}),
+        (["--tag=foo"], {"tag": ("foo",)}),
+        (["--base-url=https://example.com/api/v1test"], {"base_url": "https://example.com/api/v1test"}),
     ),
 )
 def test_load_schema_arguments(cli, mocker, args, expected):
-    mocker.patch("schemathesis.runner.execute_from_schema", autospec=True)
+    mocker.patch("schemathesis.runner.SingleThreadRunner.execute", autospec=True)
     load_schema = mocker.patch("schemathesis.runner.load_schema", autospec=True)
 
-    result = cli.run(*args)
+    result = cli.run(SCHEMA_URI, *args)
     expected = {
         "app": None,
         "base_url": None,
@@ -313,11 +317,10 @@ def test_load_schema_arguments(cli, mocker, args, expected):
 
 
 def test_all_checks(cli, mocker):
-    mocker.patch("schemathesis.runner.load_schema", autospec=True)
     execute = mocker.patch("schemathesis.runner.execute_from_schema", autospec=True)
     result = cli.run(SCHEMA_URI, "--checks=all")
     assert result.exit_code == ExitCode.OK
-    assert execute.call_args[0][1] == ALL_CHECKS
+    assert execute.call_args[1]["checks"] == ALL_CHECKS
 
 
 @pytest.mark.endpoints()
@@ -377,7 +380,7 @@ def test_cli_run_output_success(cli, cli_args, workers):
     assert "== 1 passed in " in last_line
     # And the running time is a small positive number
     time = float(last_line.split(" ")[-2].replace("s", ""))
-    assert 0 < time < 5
+    assert 0 <= time < 5
 
 
 @pytest.mark.parametrize("workers", (1, 2))

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -116,7 +116,7 @@ def test_content_type_conformance_valid(spec, response, case):
         },
     ),
 )
-@pytest.mark.parametrize("content_type, is_error", (("application/json", False), ("application/xml", True),))
+@pytest.mark.parametrize("content_type, is_error", (("application/json", False), ("application/xml", True)))
 def test_content_type_conformance_integration(raw_schema, content_type, is_error):
     schema = schemathesis.from_dict(raw_schema)
     endpoint = schema.endpoints["/users"]["get"]

--- a/test/runner/test_events.py
+++ b/test/runner/test_events.py
@@ -1,0 +1,10 @@
+from schemathesis.runner import events
+
+
+def test_unknown_exception():
+    try:
+        1 / 0
+    except Exception as exc:
+        event = events.InternalError.from_exc(exc)
+        assert event.message == "An internal error happened during a test run"
+        assert event.exception.strip() == "ZeroDivisionError: division by zero"

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -16,9 +16,9 @@ from schemathesis import converter
             {"x-nullable": True, "type": "integer", "enum": [1, 2]},
             {"anyOf": [{"type": "integer", "enum": [1, 2]}, {"type": "null"}]},
         ),
-        ({"type": "integer", "minimum": 0, "exclusiveMinimum": True}, {"type": "integer", "exclusiveMinimum": 0},),
-        ({"type": "integer", "maximum": 0, "exclusiveMaximum": True}, {"type": "integer", "exclusiveMaximum": 0},),
-        ({"type": "integer", "maximum": 0, "exclusiveMaximum": False}, {"type": "integer", "maximum": 0},),
+        ({"type": "integer", "minimum": 0, "exclusiveMinimum": True}, {"type": "integer", "exclusiveMinimum": 0}),
+        ({"type": "integer", "maximum": 0, "exclusiveMaximum": True}, {"type": "integer", "exclusiveMaximum": 0}),
+        ({"type": "integer", "maximum": 0, "exclusiveMaximum": False}, {"type": "integer", "maximum": 0}),
     ),
 )
 def test_to_jsonschema(schema, expected):

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -185,7 +185,7 @@ def test_valid_headers(base_url, swagger_20):
     inner()
 
 
-@pytest.mark.parametrize("value, expected", (({"key": "1"}, True), ({"key": 1}, True), ({"key": "\udcff"}, False),))
+@pytest.mark.parametrize("value, expected", (({"key": "1"}, True), ({"key": 1}, True), ({"key": "\udcff"}, False)))
 def test_is_valid_query(value, expected):
     assert is_valid_query(value) == expected
 


### PR DESCRIPTION
Data is mostly copied into events. It makes CLI decoupled from the runner, which
leads to a unified design of all future `runner` users.

TODO:

- [x] Distribute test results across events