### PR TITLE
refactor: Remove unused `schema` argument from runner internals

### DIFF
--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -62,7 +62,6 @@ class BaseRunner:
 
 
 def run_test(
-    schema: BaseSchema,
     endpoint: Endpoint,
     test: Union[Callable, InvalidSchema],
     checks: Iterable[CheckFunction],

--- a/src/schemathesis/runner/impl/solo.py
+++ b/src/schemathesis/runner/impl/solo.py
@@ -18,13 +18,7 @@ class SingleThreadRunner(BaseRunner):
         with get_session(auth, self.headers) as session:
             for endpoint, test in self.schema.get_all_tests(network_test, self.hypothesis_settings, self.seed):
                 for event in run_test(
-                    self.schema,
-                    endpoint,
-                    test,
-                    self.checks,
-                    results,
-                    session=session,
-                    request_timeout=self.request_timeout,
+                    endpoint, test, self.checks, results, session=session, request_timeout=self.request_timeout,
                 ):
                     yield event
                     if isinstance(event, events.Interrupted):
@@ -36,14 +30,7 @@ class SingleThreadWSGIRunner(SingleThreadRunner):
     def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
         for endpoint, test in self.schema.get_all_tests(wsgi_test, self.hypothesis_settings, self.seed):
             for event in run_test(
-                self.schema,
-                endpoint,
-                test,
-                self.checks,
-                results,
-                auth=self.auth,
-                auth_type=self.auth_type,
-                headers=self.headers,
+                endpoint, test, self.checks, results, auth=self.auth, auth_type=self.auth_type, headers=self.headers,
             ):
                 yield event
                 if isinstance(event, events.Interrupted):

--- a/src/schemathesis/runner/impl/threadpool.py
+++ b/src/schemathesis/runner/impl/threadpool.py
@@ -9,7 +9,6 @@ import hypothesis
 
 from ..._hypothesis import make_test_or_exception
 from ...models import CheckFunction, TestResultSet
-from ...schemas import BaseSchema
 from ...types import RawAuth
 from ...utils import capture_hypothesis_output, get_requests_auth
 from .. import events
@@ -20,7 +19,6 @@ def _run_task(
     test_template: Callable,
     tasks_queue: Queue,
     events_queue: Queue,
-    schema: BaseSchema,
     checks: Iterable[CheckFunction],
     settings: hypothesis.settings,
     seed: Optional[int],
@@ -32,14 +30,13 @@ def _run_task(
         while not tasks_queue.empty():
             endpoint = tasks_queue.get()
             test = make_test_or_exception(endpoint, test_template, settings, seed)
-            for event in run_test(schema, endpoint, test, checks, results, **kwargs):
+            for event in run_test(endpoint, test, checks, results, **kwargs):
                 events_queue.put(event)
 
 
 def thread_task(
     tasks_queue: Queue,
     events_queue: Queue,
-    schema: BaseSchema,
     checks: Iterable[CheckFunction],
     settings: hypothesis.settings,
     auth: Optional[RawAuth],
@@ -56,15 +53,12 @@ def thread_task(
     # pylint: disable=too-many-arguments
     prepared_auth = get_requests_auth(auth, auth_type)
     with get_session(prepared_auth, headers) as session:
-        _run_task(
-            network_test, tasks_queue, events_queue, schema, checks, settings, seed, results, session=session, **kwargs
-        )
+        _run_task(network_test, tasks_queue, events_queue, checks, settings, seed, results, session=session, **kwargs)
 
 
 def wsgi_thread_task(
     tasks_queue: Queue,
     events_queue: Queue,
-    schema: BaseSchema,
     checks: Iterable[CheckFunction],
     settings: hypothesis.settings,
     seed: Optional[int],
@@ -72,7 +66,7 @@ def wsgi_thread_task(
     kwargs: Any,
 ) -> None:
     # pylint: disable=too-many-arguments
-    _run_task(wsgi_test, tasks_queue, events_queue, schema, checks, settings, seed, results, **kwargs)
+    _run_task(wsgi_test, tasks_queue, events_queue, checks, settings, seed, results, **kwargs)
 
 
 def stop_worker(thread_id: int) -> None:
@@ -147,7 +141,6 @@ class ThreadPoolRunner(BaseRunner):
         return {
             "tasks_queue": tasks_queue,
             "events_queue": events_queue,
-            "schema": self.schema,
             "checks": self.checks,
             "settings": self.hypothesis_settings,
             "auth": self.auth,
@@ -167,7 +160,6 @@ class ThreadPoolWSGIRunner(ThreadPoolRunner):
         return {
             "tasks_queue": tasks_queue,
             "events_queue": events_queue,
-            "schema": self.schema,
             "checks": self.checks,
             "settings": self.hypothesis_settings,
             "seed": self.seed,


### PR DESCRIPTION
Not needed since 2270e00147d90360fa0152bfb13ef380c278f38d