### PR TITLE
WIP: feat: Support ASGI applications

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -467,6 +467,17 @@ python-versions = "*"
 version = "2.1.0"
 
 [[package]]
+category = "main"
+description = "The little ASGI library that shines."
+name = "starlette"
+optional = false
+python-versions = ">=3.6"
+version = "0.13.3"
+
+[package.extras]
+full = ["aiofiles", "graphene", "itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "ujson"]
+
+[[package]]
 category = "dev"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
@@ -533,7 +544,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "4503509125b915fe5522599ff3d497aa8f546b450db014d5b4f3ff6010d894e5"
+content-hash = "dabe979b739f00e9f2541b459b91b3583114eabbbc01750a700db9288305fa24"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -781,6 +792,10 @@ six = [
 sortedcontainers = [
     {file = "sortedcontainers-2.1.0-py2.py3-none-any.whl", hash = "sha256:d9e96492dd51fae31e60837736b38fe42a187b5404c16606ff7ee7cd582d4c60"},
     {file = "sortedcontainers-2.1.0.tar.gz", hash = "sha256:974e9a32f56b17c1bac2aebd9dcf197f3eb9cd30553c5852a3187ad162e1a03a"},
+]
+starlette = [
+    {file = "starlette-0.13.3-py3-none-any.whl", hash = "sha256:b316d53119813d12fa1d02ae80ef11a71ff603ff10abb143bd4aaadb59d03dd9"},
+    {file = "starlette-0.13.3.tar.gz", hash = "sha256:e15689e130a358c5cb220b9aad1e7bcb8052504c321235dab431f065c77f010d"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.1-py2-none-any.whl", hash = "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ requests = "^2.22"
 click = "^7.0"
 importlib_metadata = { version = "^1.1", python = "<3.8" }
 werkzeug = ">0.16.0"
+starlette = "^0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^4.5"

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -108,7 +108,7 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
     type=str,
     callback=callbacks.validate_base_url,
 )
-@click.option("--app", help="WSGI application to test.", type=str, callback=callbacks.validate_app)
+@click.option("--app", help="WSGI/ASGI application to test.", type=str, callback=callbacks.validate_app)
 @click.option(
     "--request-timeout",
     help="Timeout in milliseconds for network requests during the test run.",

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -7,6 +7,8 @@ import jsonschema
 import requests
 import yaml
 from jsonschema import ValidationError
+from starlette.testclient import TestClient as ASGIClient
+from starlette.applications import Starlette
 from werkzeug.test import Client
 
 from . import spec_schemas
@@ -191,6 +193,8 @@ def from_wsgi(
 
 
 def get_loader_for_app(app: Any) -> Callable:
+    if isinstance(app, Starlette):
+        return from_asgi
     if app.__class__.__module__.startswith("aiohttp."):
         return from_aiohttp
     return from_wsgi
@@ -216,4 +220,33 @@ def from_aiohttp(
         base_url = app_url
     return from_uri(
         url, base_url=base_url, method=method, endpoint=endpoint, tag=tag, validate_schema=validate_schema, **kwargs
+    )
+
+
+def from_asgi(
+    schema_path: str,
+    app: Any,
+    base_url: Optional[str] = None,
+    method: Optional[Filter] = None,
+    endpoint: Optional[Filter] = None,
+    tag: Optional[Filter] = None,
+    validate_schema: bool = True,
+    **kwargs: Any,
+) -> BaseSchema:
+    kwargs.setdefault("headers", {}).setdefault("User-Agent", USER_AGENT)
+    client = ASGIClient(app)
+    response = client.get(schema_path, **kwargs)
+    # Raising exception to provide unified behavior
+    # E.g. it will be handled in CLI - a proper error message will be shown
+    if 400 <= response.status_code < 600:
+        raise HTTPError(response=response, url=schema_path)
+    return from_file(
+        response.text,
+        location=schema_path,
+        base_url=base_url,
+        method=method,
+        endpoint=endpoint,
+        tag=tag,
+        app=app,
+        validate_schema=validate_schema,
     )

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -222,6 +222,7 @@ def load_schema(
             # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with
             # the given app
             loader = loaders.get_loader_for_app(app)
+            loader_options.update(dict_true_values(headers=headers))
         else:
             loader_options.update(dict_true_values(headers=headers, auth=auth, auth_type=auth_type))
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -176,7 +176,7 @@ def test_commands_run_help(cli):
         "  -b, --base-url TEXT             Base URL address of the API, required for",
         "                                  SCHEMA if specified by file.",
         "",
-        "  --app TEXT                      WSGI application to test.",
+        "  --app TEXT                      WSGI/ASGI application to test.",
         "  --request-timeout INTEGER RANGE",
         "                                  Timeout in milliseconds for network requests",
         "                                  during the test run.",


### PR DESCRIPTION
This commit adds support to run ASGI applications directly from CLI
using `--app` option or in-code using `from_asgi`.

It is currently based on Starlette's TestClient.

WIP: App can be loaded correctly but can't run because new runners
needs to be created (along with support functions):

- SingleThreadASGIRunner
- ThreadPoolASGIRunner