### PR TITLE
fix: Code samples for schemas where `body` is defined as `{"type": "string"}`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Code samples for schemas where ``body`` is defined as ``{"type": "string"}``. `#521`_
+
 Changed
 ~~~~~~~
 
@@ -918,6 +923,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#521: https://github.com/kiwicom/schemathesis/issues/521
 .. _#504: https://github.com/kiwicom/schemathesis/issues/504
 .. _#499: https://github.com/kiwicom/schemathesis/issues/499
 .. _#497: https://github.com/kiwicom/schemathesis/issues/497

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -67,7 +67,7 @@ class Case:
             return value == default_value
 
         printed_kwargs = ", ".join(
-            f"{key}={value}"
+            f"{key}={repr(value)}"
             for key, value in kwargs.items()
             if key not in ("method", "url") and not are_defaults(key, value)
         )
@@ -93,7 +93,7 @@ class Case:
         formatted_path = self.formatted_path.lstrip("/")  # pragma: no mutate
         url = urljoin(base_url + "/", formatted_path)
         # Form data and body are mutually exclusive
-        extra: Dict[str, Optional[Union[Dict, bytes]]]
+        extra: Dict[str, Optional[Body]]
         if self.form_data:
             extra = {"files": self.form_data}
         elif is_multipart(self.body):
@@ -129,7 +129,7 @@ class Case:
     def as_werkzeug_kwargs(self) -> Dict[str, Any]:
         """Convert the case into a dictionary acceptable by werkzeug.Client."""
         headers = self.headers
-        extra: Dict[str, Optional[Union[Dict, bytes]]]
+        extra: Dict[str, Optional[Body]]
         if self.form_data:
             extra = {"data": self.form_data}
             headers = headers or {}
@@ -176,7 +176,7 @@ class Case:
             raise AssertionError(*errors)
 
 
-def is_multipart(item: Optional[Union[bytes, Dict[str, Any], List[Any]]]) -> bool:
+def is_multipart(item: Optional[Body]) -> bool:
     """A poor detection if the body should be a multipart request.
 
     It traverses the structure and if it contains bytes in any value, then it is a multipart request, because

--- a/src/schemathesis/types.py
+++ b/src/schemathesis/types.py
@@ -7,7 +7,8 @@ Schema = NewType("Schema", Dict[str, Any])  # pragma: no mutate
 PathLike = Union[Path, str]  # pragma: no mutate
 
 Query = Dict[str, Any]  # pragma: no mutate
-Body = Union[Dict[str, Any], bytes]  # pragma: no mutate
+# Body can be of any Python type that corresponds to JSON Schema types + `bytes`
+Body = Union[List, Dict[str, Any], str, int, float, bool, bytes]  # pragma: no mutate
 PathParameters = Dict[str, Any]  # pragma: no mutate
 Headers = Dict[str, Any]  # pragma: no mutate
 Cookies = Dict[str, Any]  # pragma: no mutate

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -65,7 +65,13 @@ ENDPOINT = Endpoint("/api/success", "GET", {}, base_url="http://example.com", sc
 @pytest.mark.parametrize(
     "case, expected",
     (
+        # Body can be of any primitive type supported by Open API
         (Case(ENDPOINT, body={"test": 1}), "requests.get('http://example.com/api/success', json={'test': 1})"),
+        (Case(ENDPOINT, body=["foo"]), "requests.get('http://example.com/api/success', json=['foo'])"),
+        (Case(ENDPOINT, body="foo"), "requests.get('http://example.com/api/success', json='foo')"),
+        (Case(ENDPOINT, body=1), "requests.get('http://example.com/api/success', json=1)"),
+        (Case(ENDPOINT, body=1.1), "requests.get('http://example.com/api/success', json=1.1)"),
+        (Case(ENDPOINT, body=True), "requests.get('http://example.com/api/success', json=True)"),
         (Case(ENDPOINT), "requests.get('http://example.com/api/success')"),
         (Case(ENDPOINT, query={"a": 1}), "requests.get('http://example.com/api/success', params={'a': 1})"),
     ),


### PR DESCRIPTION
Fixes #521 