### PR TITLE
feat: Replay cassettes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Added
 - Storing network logs with ``--store-network-log=<filename.yaml>``.
   The stored cassettes are based on the `VCR format <https://relishapp.com/vcr/vcr/v/5-1-0/docs/cassettes/cassette-format>`_
   and contain extra information from the Schemathesis internals. `#379`_
+- Replaying of cassettes stored in VCR format. `#519`_
 - Targeted property-based testing in CLI and runner. It only supports ``response_time`` target at the moment. `#104`_
 - Export CLI test results to JUnit.xml with ``--junit-xml=<filename.xml>``. `#427`_
 
@@ -941,6 +942,7 @@ Fixed
 
 .. _#529: https://github.com/kiwicom/schemathesis/issues/529
 .. _#521: https://github.com/kiwicom/schemathesis/issues/521
+.. _#519: https://github.com/kiwicom/schemathesis/issues/519
 .. _#513: https://github.com/kiwicom/schemathesis/issues/513
 .. _#504: https://github.com/kiwicom/schemathesis/issues/504
 .. _#499: https://github.com/kiwicom/schemathesis/issues/499

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,6 +72,36 @@ Check payload in requests to ``/api/upload_file``:
 
     --7d4db38ad065994d913cb02b2982e3ba--
 
+Replaying interactions
+----------------------
+
+Saved cassettes can be replayed with ``schemathesis replay`` command. Additionally, you may filter what interactions to
+replay by these parameters:
+
+- ``id``. Specific, unique ID;
+- ``status``. Replay only interactions with this status (``SUCCESS``, ``FAILURE`` or``ERROR``);
+- ``uri``. A regular expression for request URI;
+- ``method``. A regular expression for request method;
+
+During replaying Schemathesis will output interactions being replayed together with the response codes from the initial and
+current execution:
+
+.. code:: bash
+
+    $ schemathesis replay foo.yaml --status=FAILURE
+    Replaying cassette: foo.yaml
+    Total interactions: 4005
+
+      ID              : 0
+      URI             : http://127.0.0.1:8081/api/failure
+      Old status code : 500
+      New status code : 500
+
+      ID              : 1
+      URI             : http://127.0.0.1:8081/api/failure
+      Old status code : 500
+      New status code : 500
+
 Export CLI test results to JUnit.xml
 ------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "werkzeug", "yaml"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "urllib3", "werkzeug", "yaml"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/schemathesis/cli/cassettes.py
+++ b/src/schemathesis/cli/cassettes.py
@@ -1,10 +1,15 @@
+import base64
+import re
 import sys
 import threading
 from queue import Queue
-from typing import Dict, List, cast
+from typing import Any, Dict, Generator, Iterator, List, Optional, cast
 
 import attr
 import click
+import requests
+from requests.cookies import RequestsCookieJar
+from requests.structures import CaseInsensitiveDict
 
 from .. import constants
 from ..models import Interaction
@@ -138,3 +143,82 @@ http_interactions:"""
         else:
             break
     file_handle.close()
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class Replayed:
+    interaction: Dict[str, Any] = attr.ib()  # pragma: no mutate
+    response: requests.Response = attr.ib()  # pragma: no mutate
+
+
+def replay(
+    cassette: Dict[str, Any],
+    id_: Optional[str] = None,
+    status: Optional[str] = None,
+    uri: Optional[str] = None,
+    method: Optional[str] = None,
+) -> Generator[Replayed, None, None]:
+    """Replay saved interactions."""
+    session = requests.Session()
+    for interaction in filter_cassette(cassette["http_interactions"], id_, status, uri, method):
+        request = get_prepared_request(interaction["request"])
+        response = session.send(request)  # type: ignore
+        yield Replayed(interaction, response)
+
+
+def filter_cassette(
+    interactions: List[Dict[str, Any]],
+    id_: Optional[str] = None,
+    status: Optional[str] = None,
+    uri: Optional[str] = None,
+    method: Optional[str] = None,
+) -> Iterator[Dict[str, Any]]:
+
+    filters = []
+
+    def id_filter(item: Dict[str, Any]) -> bool:
+        return item["id"] == id_
+
+    def status_filter(item: Dict[str, Any]) -> bool:
+        status_ = cast(str, status)
+        return item["status"].upper() == status_.upper()
+
+    def uri_filter(item: Dict[str, Any]) -> bool:
+        uri_ = cast(str, uri)
+        return bool(re.search(uri_, item["request"]["uri"]))
+
+    def method_filter(item: Dict[str, Any]) -> bool:
+        method_ = cast(str, method)
+        return bool(re.search(method_, item["request"]["method"]))
+
+    if id_ is not None:
+        filters.append(id_filter)
+
+    if status is not None:
+        filters.append(status_filter)
+
+    if uri is not None:
+        filters.append(uri_filter)
+
+    if method is not None:
+        filters.append(method_filter)
+
+    def is_match(interaction: Dict[str, Any]) -> bool:
+        return all(filter_(interaction) for filter_ in filters)
+
+    return filter(is_match, interactions)
+
+
+def get_prepared_request(data: Dict[str, Any]) -> requests.PreparedRequest:
+    """Create a `requests.PreparedRequest` from a serialized one."""
+    prepared = requests.PreparedRequest()
+    prepared.method = data["method"]
+    prepared.url = data["uri"]
+    prepared._cookies = RequestsCookieJar()  # type: ignore
+    encoded = data["body"]["base64_string"]
+    if encoded:
+        prepared.body = base64.b64decode(encoded)
+    # There is always 1 value in a request
+    headers = [(key, value[0]) for key, value in data["headers"].items()]
+    prepared.headers = CaseInsensitiveDict(headers)
+    return prepared

--- a/test/apps/_aiohttp/__init__.py
+++ b/test/apps/_aiohttp/__init__.py
@@ -42,8 +42,7 @@ def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> web.Appli
 
         @wraps(handler)
         async def inner(request: web.Request) -> web.Response:
-            if "Content-Type" in request.headers and not request.headers["Content-Type"].startswith("multipart/"):
-                await request.read()
+            await request.read()  # to introspect the payload in tests
             incoming_requests.append(request)
             return await handler(request)
 

--- a/test/apps/_flask/__init__.py
+++ b/test/apps/_flask/__init__.py
@@ -47,6 +47,10 @@ def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> Flask:
     def payload():
         return jsonify(request.json)
 
+    @app.route("/api/get_payload", methods=["GET"])
+    def get_payload():
+        return jsonify(request.json)
+
     @app.route("/api/failure", methods=["GET"])
     def failure():
         raise InternalServerError

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -6,6 +6,8 @@ class Endpoint(Enum):
     success = ("GET", "/api/success")
     failure = ("GET", "/api/failure")
     payload = ("POST", "/api/payload")
+    # Not compliant, but used by some tools like Elasticsearch
+    get_payload = ("GET", "/api/get_payload")
     multiple_failures = ("GET", "/api/multiple_failures")
     slow = ("GET", "/api/slow")
     path_variable = ("GET", "/api/path_variable/{key}")
@@ -56,7 +58,7 @@ def make_schema(endpoints: Tuple[str, ...]) -> Dict:
                     "value": {"type": "integer", "maximum": 4, "exclusiveMaximum": True},
                 },
             }
-        elif endpoint == "payload":
+        elif endpoint in ("payload", "get_payload"):
             payload = {
                 "type": "object",
                 "properties": {

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -35,7 +35,8 @@ def test_commands_help(cli):
 
     assert result.exit_code == ExitCode.OK
     lines = result.stdout.split("\n")
-    assert lines[11] == "  run  Perform schemathesis test."
+    assert lines[11] == "  replay  Replay requests from a saved cassette."
+    assert lines[12] == "  run     Perform schemathesis test."
 
     result_help = cli.main("--help")
     result_h = cli.main("-h")


### PR DESCRIPTION
Resolves #519 

TODO:

- [x] GET requests with payload (e.g. Elasticsearch uses such requests)
- [x] Multiple values in headers (e.g cookies)
- [x] verify that cookies are working (they should when headers will be handled completely)
- [x] Test different endpoints, compare headers
- [x] CLI options for filtering cassettes (ID, status, URL, method)
- [x] Cassette validation via Click callback
- [x] A bit more docstrings 
- [x] Output useful info to CLI
- [x] Docs