### PR TITLE
perf: Improve cassette writer performance

### DIFF
--- a/src/schemathesis/cli/cassettes.py
+++ b/src/schemathesis/cli/cassettes.py
@@ -1,26 +1,16 @@
 import sys
 import threading
-from contextlib import contextmanager
 from queue import Queue
-from typing import Any, Dict, Generator, List, Optional, cast
+from typing import Dict, List, cast
 
 import attr
 import click
-import yaml
-from yaml.serializer import Serializer
 
 from .. import constants
 from ..models import Interaction
 from ..runner import events
 from .context import ExecutionContext
 from .handlers import EventHandler
-
-try:
-    from yaml import CDumper as Dumper
-except ImportError:
-    # pylint: disable=unused-import
-    from yaml import Loader, Dumper  # type: ignore
-
 
 # Wait until the worker terminates
 WRITER_WORKER_JOIN_TIMEOUT = 1
@@ -52,11 +42,10 @@ class CassetteWriter(EventHandler):
             seed = cast(int, event.result.seed)
             self.queue.put(Process(status=event.status.name.upper(), seed=seed, interactions=event.result.interactions))
         if isinstance(event, events.Finished):
-            self.queue.put(Finalize())
-            self._stop_worker()
+            self.shutdown()
 
     def shutdown(self) -> None:
-        self.queue.put(Shutdown())
+        self.queue.put(Finalize())
         self._stop_worker()
 
     def _stop_worker(self) -> None:
@@ -78,52 +67,8 @@ class Process:
 
 
 @attr.s(slots=True)  # pragma: no mutate
-class Shutdown:
-    """There is an exception in the main process and the worker should be shut down immediately."""
-
-
-@attr.s(slots=True)  # pragma: no mutate
 class Finalize:
     """The work is done and there will be no more messages to process."""
-
-
-class StringSerializer(Serializer):
-    """Emit scalar values as strings.
-
-    It is required to avoid possible issues with default YAML parsing.
-    For example "Norway problem", where `- no` will be parsed to `[False]`, but we have strings everywhere
-    therefore we need `- 'no'` and ['no'].
-    """
-
-    def serialize_node(self, node: yaml.Node, parent: Optional[yaml.Node], index: int) -> None:
-        # NOTE. This implementation is taken from the parent Serializer and adjusted for `ScalarNode` case and
-        # for `MappingNode`.
-        alias = self.anchors[node]
-        self.serialized_nodes[node] = True
-        self.descend_resolver(parent, index)  # type: ignore
-        if isinstance(node, yaml.ScalarNode):
-            implicit = False, True
-            self.emit(yaml.ScalarEvent(alias, node.tag, implicit, node.value, style=node.style))  # type: ignore
-        elif isinstance(node, yaml.SequenceNode):
-            implicit = node.tag == self.resolve(yaml.SequenceNode, node.value, True)  # type: ignore
-            self.emit(yaml.SequenceStartEvent(alias, node.tag, implicit, flow_style=node.flow_style))  # type: ignore
-            index = 0
-            for item in node.value:
-                self.serialize_node(item, node, index)
-                index += 1
-            self.emit(yaml.SequenceEndEvent())  # type: ignore
-        elif isinstance(node, yaml.MappingNode):
-            implicit = node.tag == self.resolve(yaml.MappingNode, node.value, True)  # type: ignore
-            self.emit(yaml.MappingStartEvent(alias, node.tag, implicit, flow_style=node.flow_style))  # type: ignore
-            for key, value in node.value:
-                self.emit(yaml.ScalarEvent(alias, key.tag, (True, True), key.value, style=key.style))  # type: ignore
-                self.serialize_node(value, node, key)
-            self.emit(yaml.MappingEndEvent())  # type: ignore
-        self.ascend_resolver()  # type: ignore
-
-
-class StringDumper(Dumper, StringSerializer):
-    pass
 
 
 def get_command_representation() -> str:
@@ -136,80 +81,60 @@ def get_command_representation() -> str:
 
 
 def worker(file_handle: click.utils.LazyFile, queue: Queue) -> None:
-    """Write YAML to a file in an incremental manner."""
+    """Write YAML to a file in an incremental manner.
+
+    This implementation doesn't use `pyyaml` package and composes YAML manually as string due to the following reasons:
+      - It is much faster. The string-based approach gives only ~2.5% time overhead when `yaml.CDumper` has ~11.2%;
+      - Implementation complexity. We have a quite simple format where all values are strings and it is much simpler to
+        implement it with string composition rather than with adjusting `yaml.Serializer` to emit explicit types.
+        Another point is that with `pyyaml` we need to emit events and handle some low-level details like providing
+        tags, anchors to have incremental writing, with strings it is much simpler.
+    """
     current_id = 1
     stream = file_handle.open()
-    dumper = StringDumper(stream, sort_keys=False)  # type: ignore
-    StringSerializer.__init__(dumper)  # type: ignore
-    dumper.open()  # type: ignore
 
-    # Helpers
+    def format_header_values(values: List[str]) -> str:
+        return "\n".join(f"      - '{v}'" for v in values)
 
-    def emit(*yaml_events: yaml.Event) -> None:
-        for event in yaml_events:
-            dumper.emit(event)  # type: ignore
-
-    def close_dumper() -> None:
-        # C-extension is not introspectable
-        dumper.close()  # type: ignore
-        dumper.dispose()  # type: ignore
-
-    @contextmanager
-    def mapping() -> Generator[None, None, None]:
-        emit(yaml.MappingStartEvent(anchor=None, tag=None, implicit=True))
-        yield
-        emit(yaml.MappingEndEvent())
-
-    def key(name: str) -> yaml.ScalarEvent:
-        """Default style for mapping keys is without quotes."""
-        return yaml.ScalarEvent(anchor=None, tag=None, implicit=(True, True), value=name)
-
-    def value(_value: str) -> yaml.ScalarEvent:
-        """Default style for mapping values is with quotes."""
-        return yaml.ScalarEvent(anchor=None, tag=None, implicit=(False, True), value=_value)
-
-    def serialize_mapping(name: str, data: Dict[str, Any]) -> None:
-        emit(key(name))
-        node = dumper.represent_data(data)  # type: ignore
-        # C-extension is not introspectable
-        dumper.anchor_node(node)  # type: ignore
-        dumper.serialize_node(node, None, 0)  # type: ignore
+    def format_headers(headers: Dict[str, List[str]]) -> str:
+        return "\n".join(f"      {name}:\n{format_header_values(values)}" for name, values in headers.items())
 
     while True:
         item = queue.get()
         if isinstance(item, Initialize):
-            emit(yaml.DocumentStartEvent(), yaml.MappingStartEvent(anchor=None, tag=None, implicit=True))
-            emit(
-                key("command"),
-                value(get_command_representation()),
-                key("recorded_with"),
-                value(f"Schemathesis {constants.__version__}"),
-                key("http_interactions"),
-                yaml.SequenceStartEvent(anchor=None, tag=None, implicit=True),
+            stream.write(
+                f"""command: '{get_command_representation()}'
+recorded_with: 'Schemathesis {constants.__version__}'
+http_interactions:"""
             )
         elif isinstance(item, Process):
             for interaction in item.interactions:
-                with mapping():
-                    emit(
-                        key("id"),
-                        value(str(current_id)),
-                        key("status"),
-                        value(item.status),
-                        key("seed"),
-                        value(str(item.seed)),
-                        key("elapsed"),
-                        value(str(interaction.response.elapsed)),
-                        key("recorded_at"),
-                        value(interaction.recorded_at),
-                    )
-                    serialize_mapping("request", interaction.request.asdict())
-                    serialize_mapping("response", interaction.response.asdict())
+                stream.write(
+                    f"""\n- id: '{current_id}'
+  status: '{item.status}'
+  seed: '{item.seed}'
+  elapsed: '{interaction.response.elapsed}'
+  recorded_at: '{interaction.recorded_at}'
+  request:
+    uri: '{interaction.request.uri}'
+    method: '{interaction.request.method}'
+    headers:
+{format_headers(interaction.request.headers)}
+    body:
+      encoding: 'utf-8'
+      base64_string: '{interaction.request.body}'
+  response:
+    status:
+      code: '{interaction.response.status_code}'
+      message: '{interaction.response.message}'
+    headers:
+{format_headers(interaction.response.headers)}
+    body:
+      encoding: '{interaction.response.encoding}'
+      base64_string: '{interaction.response.body}'
+    http_version: '{interaction.response.http_version}'"""
+                )
                 current_id += 1
-        elif isinstance(item, Shutdown):
-            close_dumper()
-            break
         else:
-            emit(yaml.SequenceEndEvent(), yaml.MappingEndEvent(), yaml.DocumentEndEvent())
-            close_dumper()
             break
     file_handle.close()

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -298,15 +298,6 @@ class Request:
             body=base64.b64encode(body).decode(),
         )
 
-    def asdict(self) -> Dict[str, Union[str, Dict[str, str]]]:
-        """For compatibility with VCR we need to adjust the structure a bit."""
-        return {
-            "uri": self.uri,
-            "method": self.method,
-            "headers": self.headers,
-            "body": {"encoding": "utf-8", "base64_string": self.body},
-        }
-
 
 def serialize_payload(payload: bytes) -> str:
     return base64.b64encode(payload).decode()
@@ -354,14 +345,6 @@ class Response:
             http_version="1.1",
             elapsed=elapsed,
         )
-
-    def asdict(self) -> Dict[str, Union[str, Dict[str, str], Dict[str, List[str]]]]:
-        return {
-            "status": {"code": str(self.status_code), "message": self.message},
-            "headers": self.headers,
-            "body": {"encoding": self.encoding, "base64_string": self.body},
-            "http_version": self.http_version,
-        }
 
 
 @attr.s(slots=True)  # pragma: no mutate


### PR DESCRIPTION
Since cassettes writer adds a certain overhead I looked for ways to improve performance.

Here some performance benchmarks I did with the current implementation (with using [hyperfine](https://github.com/sharkdp/hyperfine) on default settings and `-i` option to ignore non-zero exit codes).

#### HTTP
The built-in test server was used with the following config:

```./test_server.sh 8081 --endpoints=success,failure,path_variable,multipart,recursive,multipart,payload,upload_file```

Command: `schemathesis run --hypothesis-max-examples=1000 --hypothesis-seed=1 --hypothesis-deadline=None http://127.0.0.1:8081/swagger.yaml` + `--store-network-log=cassette.yaml` in relevant cases

No cassettes: 11.222 s (baseline)
Current implementation with C-extension: 12.504 s (**+11.4%**)
Current implementation without C-extension: 17.058 s (**+52%**)

#### WSGI
The same test server config was used but with Flask-based implementation.
Command: `PYTHONPATH=`pwd` schemathesis run --app=test.apps._flask.app:app --hypothesis-max-examples=1000 --hypothesis-seed=1 --hypothesis-deadline=None /swagger.yaml`  + `--store-network-log=cassette.yaml` in relevant cases

No cassettes: 8.188 s (baseline)
Current implementation with C-extension: 10.616 s (**+29.6%**)
Current implementation without C-extension: 14.252 s (**+74%**)

#### Investigated approaches

1. Rust. Unfortunately `yaml_rust` [does not expose](https://github.com/chyh1990/yaml-rust/blob/master/src/emitter.rs#L159) `emit_node` and it is problematic to have incremental writing. Then `serde-yaml` doesn't expose `Serializer` which makes things even more complicated. So, I gave up there

2. Composing strings instead of using `pyyaml`. We have a simple format and it turned out that composing  YAML with string formatting is much simpler to implement than it was with the current approach.

Here are results for the string-based approach

HTTP: 11.512 s (**+2.5%**)
WSGI: 9.740 s (**+18.9%**)

I feel that this approach is a bit hacky since YAML is composed manually, but having a much simpler implementation than `pyyaml`-based one and that performance gain makes me think that it worth having.