### PR TITLE
fix: Recursion error in `response_schema_conformance` check

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Fixed
 
 - Code samples for schemas where ``body`` is defined as ``{"type": "string"}``. `#521`_
 - Showing error causes on internal ``jsonschema`` errors during input schema validation. `#513`_
+- Recursion error in ``response_schema_conformance`` check. Because of this change ``Endpoint.definition`` contains
+  a definition where references are not resolved. In this way it makes possible to avoid recursion errors
+  in ``jsonschema`` validation. `#468`_
 
 Changed
 ~~~~~~~

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -352,8 +352,7 @@ def test_response_conformance_valid(args):
 
 
 @pytest.mark.endpoints("recursive")
-def test_response_conformance_recursive_valid(mocker, schema_url):
-    mocker.patch("schemathesis.schemas.RECURSION_DEPTH_LIMIT", 1)
+def test_response_conformance_recursive_valid(schema_url):
     # When endpoint contains a response that have recursive references
     # And "response_schema_conformance" is specified
     results = execute(schema_url, checks=(response_schema_conformance,), hypothesis_max_examples=1)

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -560,43 +560,12 @@ def test_complex_dereference(testdir):
         definition={
             "requestBody": {
                 "content": {
-                    "application/json": {
-                        "schema": {
-                            "additionalProperties": False,
-                            "description": "Test",
-                            "properties": {
-                                "profile": {
-                                    "additionalProperties": False,
-                                    "description": "Test",
-                                    "properties": {"id": {"type": "integer"}},
-                                    "required": ["id"],
-                                    "type": "object",
-                                },
-                                "username": {"type": "string"},
-                            },
-                            "required": ["username", "profile"],
-                            "type": "object",
-                        }
-                    }
+                    "application/json": {"schema": {"$ref": "../schemas/teapot/create.yaml#/TeapotCreateRequest"}}
                 },
                 "description": "Test.",
                 "required": True,
             },
-            "responses": {
-                "default": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "additionalProperties": False,
-                                "properties": {"key": {"type": "string"}},
-                                "required": ["key"],
-                                "type": "object",
-                            }
-                        }
-                    },
-                    "description": "Probably an error",
-                }
-            },
+            "responses": {"default": {"$ref": "../../common/responses.yaml#/DefaultError"}},
             "summary": "Test",
             "tags": ["ancillaries"],
         },


### PR DESCRIPTION
Fixes #468 

@jeremyschiemann 
It changes `Endpoint.definition` to schemas with not resolved references, so `jsonschema.validate` won't fail. Unfortunately, it was masked with the mocking of `RECURSION_DEPTH_LIMIT` in the relevant test, so, the issue you mentioned in #468 is reproducible (hopefully).

I hope to release a new version today and would love to hear your feedback if it actually fixes the problem, which is actually my 3rd attempt on this issue :)