### PR TITLE
fix: Validation of nullable properties in `response_schema_conformance` check introduced in `1.3.0`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Validation of nullable properties in ``response_schema_conformance`` check introduced in ``1.3.0``. `#542`_
+
 `1.3.3`_ - 2020-04-29
 ---------------------
 
@@ -970,6 +975,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#542: https://github.com/kiwicom/schemathesis/issues/542
 .. _#537: https://github.com/kiwicom/schemathesis/issues/537
 .. _#529: https://github.com/kiwicom/schemathesis/issues/529
 .. _#521: https://github.com/kiwicom/schemathesis/issues/521

--- a/src/schemathesis/converter.py
+++ b/src/schemathesis/converter.py
@@ -1,11 +1,12 @@
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any, Dict, List, Union, overload
 
 
 def to_json_schema(schema: Dict[str, Any], nullable_name: str) -> Dict[str, Any]:
     """Convert Open API parameters to JSON Schema.
 
-    NOTE. This function is applied to all keywords (including nested) during schema resolving, thus it is not recursive
+    NOTE. This function is applied to all keywords (including nested) during schema resolving, thus it is not recursive.
+    See a recursive version below.
     """
     schema = deepcopy(schema)
     if schema.get(nullable_name) is True:
@@ -21,4 +22,43 @@ def to_json_schema(schema: Dict[str, Any], nullable_name: str) -> Dict[str, Any]
     if schema.get("type") == "file":
         schema["type"] = "string"
         schema["format"] = "binary"
+    return schema
+
+
+Schema = Union[Dict[str, Any], List, str, float, int]
+
+
+@overload
+def to_json_schema_recursive(schema: Dict[str, Any], nullable_name: str) -> Dict[str, Any]:
+    pass
+
+
+@overload
+def to_json_schema_recursive(schema: List, nullable_name: str) -> List:
+    pass
+
+
+@overload
+def to_json_schema_recursive(schema: str, nullable_name: str) -> str:
+    pass
+
+
+@overload
+def to_json_schema_recursive(schema: float, nullable_name: str) -> float:
+    pass
+
+
+def to_json_schema_recursive(schema: Schema, nullable_name: str) -> Schema:
+    """Apply ``to_json_schema`` recursively.
+
+    This version is needed for cases where the input schema was not resolved and ``to_json_schema`` wasn't applied
+    recursively.
+    """
+    if isinstance(schema, dict):
+        schema = to_json_schema(schema, nullable_name)
+        for key, sub_item in schema.items():
+            schema[key] = to_json_schema_recursive(sub_item, nullable_name)
+    elif isinstance(schema, list):
+        for idx, sub_item in enumerate(schema):
+            schema[idx] = to_json_schema_recursive(sub_item, nullable_name)
     return schema

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -23,7 +23,7 @@ from requests.structures import CaseInsensitiveDict
 
 from ._hypothesis import make_test_or_exception
 from .constants import HookLocation
-from .converter import to_json_schema
+from .converter import to_json_schema, to_json_schema_recursive
 from .exceptions import InvalidSchema
 from .filters import should_skip_by_tag, should_skip_endpoint, should_skip_method
 from .models import Endpoint, empty_object
@@ -365,7 +365,7 @@ class SwaggerV20(BaseSchema):
         schema = definition.get("schema")
         if not schema:
             return None
-        return to_json_schema(schema, self.nullable_name)
+        return to_json_schema_recursive(schema, self.nullable_name)
 
     def get_content_types(self, endpoint: Endpoint, response: GenericResponse) -> List[str]:
         produces = endpoint.definition.get("produces", None)
@@ -453,7 +453,7 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
         options = iter(definition.get("content", {}).values())
         option = next(options, None)
         if option:
-            return to_json_schema(option["schema"], self.nullable_name)
+            return to_json_schema_recursive(option["schema"], self.nullable_name)
         return None
 
     def get_content_types(self, endpoint: Endpoint, response: GenericResponse) -> List[str]:

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -228,6 +228,25 @@ def test_response_schema_conformance_swagger_no_content_header(swagger_20):
         (b'{"success": true}', {"responses": {"200": {"description": "text"}}}),
         (b'{"random": "text"}', {"responses": {"200": {"description": "text"}}}),
         (
+            b'{"success": null}',
+            {
+                "responses": {
+                    "200": {
+                        "description": "text",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {"success": {"type": "boolean", "nullable": True}},
+                                    "required": ["success"],
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        ),
+        (
             b'{"success": true}',
             {
                 "responses": {

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -20,3 +20,38 @@ from schemathesis import converter
 )
 def test_to_jsonschema(schema, expected):
     assert converter.to_json_schema(schema, "x-nullable") == expected
+
+
+@pytest.mark.parametrize(
+    "schema, expected",
+    (
+        (
+            {
+                "type": "object",
+                "properties": {"success": {"type": "boolean", "x-nullable": True}},
+                "required": ["success"],
+            },
+            {
+                "type": "object",
+                "properties": {"success": {"anyOf": [{"type": "boolean"}, {"type": "null"}]}},
+                "required": ["success"],
+            },
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"success": {"type": "array", "items": [{"type": "boolean", "x-nullable": True}]}},
+                "required": ["success"],
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "success": {"type": "array", "items": [{"anyOf": [{"type": "boolean"}, {"type": "null"}]}]}
+                },
+                "required": ["success"],
+            },
+        ),
+    ),
+)
+def test_to_jsonschema_recursive(schema, expected):
+    assert converter.to_json_schema_recursive(schema, "x-nullable") == expected


### PR DESCRIPTION
Resolves #542 