### PR TITLE
feat: Add `context` argument to hook functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -405,25 +405,29 @@ If you want to customize how data is generated, then you can use hooks of three 
 - Schema-local, which are applied only for specific schema instance;
 - Test function specific, they are applied only for a specific test function;
 
-Each hook accepts a Hypothesis strategy and should return a Hypothesis strategy:
+Each hook accepts a Hypothesis strategy and a hook context. Hook context provides additional info that might be helpful to
+construct a new strategy, for example ``context.endpoint`` attribute is a reference to the currently tested endpoint.
+For more information look at ``schemathesis.hooks.HookContext`` class.
+
+Hooks should return a Hypothesis strategy:
 
 .. code:: python
 
     import schemathesis
 
-    def global_hook(strategy):
+    def global_hook(strategy, context):
         return strategy.filter(lambda x: x["id"].isdigit())
 
     schemathesis.hooks.register("query", hook)
 
     schema = schemathesis.from_uri("http://0.0.0.0:8080/swagger.json")
 
-    def schema_hook(strategy):
+    def schema_hook(strategy, context):
         return strategy.filter(lambda x: int(x["id"]) % 2 == 0)
 
     schema.register_hook("query", schema_hook)
 
-    def function_hook(strategy):
+    def function_hook(strategy, context):
         return strategy.filter(lambda x: len(x["id"]) > 5)
 
     @schema.with_hook("query", function_hook)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,17 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- ``context`` argument for hook functions to provide an additional context for hooks. A deprecation warning is emitted
+  for hook functions that do not accept this argument.
+
+Deprecated
+~~~~~~~~~~
+
+- Hook functions that do not accept ``context`` as their second argument. They will become not supported in Schemathesis 2.0.
+
 Fixed
 ~~~~~
 

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -1,12 +1,35 @@
+import inspect
+import warnings
 from typing import Optional
 
+import attr
+
 from .constants import HookLocation
+from .models import Endpoint
 from .types import Hook
 
 GLOBAL_HOOKS = {}
 
 
+@attr.s(slots=True)
+class HookContext:
+    """A context that is passed to hook functions."""
+
+    endpoint: Endpoint = attr.ib()
+
+
+def warn_deprecated_hook(hook: Hook) -> None:
+    if "context" not in inspect.signature(hook).parameters:
+        warnings.warn(
+            DeprecationWarning(
+                "Hook functions that do not accept `context` argument are deprecated and "
+                "support will be removed in Schemathesis 2.0."
+            )
+        )
+
+
 def register(place: str, hook: Hook) -> None:
+    warn_deprecated_hook(hook)
     key = HookLocation[place]
     GLOBAL_HOOKS[key] = hook
 

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -26,6 +26,7 @@ from .constants import HookLocation
 from .converter import to_json_schema, to_json_schema_recursive
 from .exceptions import InvalidSchema
 from .filters import should_skip_by_tag, should_skip_endpoint, should_skip_method
+from .hooks import warn_deprecated_hook
 from .models import Endpoint, empty_object
 from .types import Filter, Hook, NotSet
 from .utils import NOT_SET, GenericResponse, StringDatesYAMLLoader
@@ -164,11 +165,13 @@ class BaseSchema(Mapping):
         raise NotImplementedError
 
     def register_hook(self, place: str, hook: Hook) -> None:
+        warn_deprecated_hook(hook)
         key = HookLocation[place]
         self.hooks[key] = hook
 
     def with_hook(self, place: str, hook: Hook) -> Callable[[GenericTest], GenericTest]:
         """Register a hook for a specific test."""
+        warn_deprecated_hook(hook)
         if place not in HookLocation.__members__:
             raise KeyError(place)
 

--- a/src/schemathesis/types.py
+++ b/src/schemathesis/types.py
@@ -1,7 +1,10 @@
 from pathlib import Path
-from typing import Any, Callable, Dict, List, NewType, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NewType, Set, Tuple, Union
 
 from hypothesis.strategies import SearchStrategy
+
+if TYPE_CHECKING:
+    from .hooks import HookContext
 
 Schema = NewType("Schema", Dict[str, Any])  # pragma: no mutate
 PathLike = Union[Path, str]  # pragma: no mutate
@@ -22,6 +25,8 @@ class NotSet:
 # A filter for endpoint / method
 Filter = Union[str, List[str], Tuple[str], Set[str], NotSet]  # pragma: no mutate
 
-Hook = Callable[[SearchStrategy], SearchStrategy]  # pragma: no mutate
+Hook = Union[
+    Callable[[SearchStrategy], SearchStrategy], Callable[[SearchStrategy, "HookContext"], SearchStrategy]
+]  # pragma: no mutate
 
 RawAuth = Tuple[str, str]  # pragma: no mutate


### PR DESCRIPTION
This will help building strategies in hooks by providing more info. It might be helpful if the test is covering multiple endpoints and the hook should adjust strategies differently, depending on the current endpoint.