### PR TITLE
add filter parameter `operationId` 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Added
 ~~~~~
 
 - Display a suggestion to disable schema validation on schema loading errors in CLI. `#531`_
+- ``operation_id`` argument can get operations accurately by operationId . `#546`_
 
 `1.4.0`_ - 2020-05-03
 ---------------------
@@ -1012,6 +1013,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#546: https://github.com/kiwicom/schemathesis/issues/546
 .. _#542: https://github.com/kiwicom/schemathesis/issues/542
 .. _#539: https://github.com/kiwicom/schemathesis/issues/539
 .. _#537: https://github.com/kiwicom/schemathesis/issues/537

--- a/src/schemathesis/filters.py
+++ b/src/schemathesis/filters.py
@@ -26,3 +26,10 @@ def should_skip_by_tag(tags: Optional[List[str]], pattern: Optional[Filter]) -> 
         return True
     patterns = force_tuple(pattern)
     return not any(re.search(item, tag) for item in patterns for tag in tags)
+
+
+def should_skip_by_operation_id(operation_id: str, pattern: Optional[Filter]) -> bool:
+    if pattern is None:
+        return False
+    patterns = force_tuple(pattern)
+    return not any(re.search(item, operation_id) for item in patterns)

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -25,6 +25,7 @@ def from_path(
     method: Optional[Filter] = None,
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     *,
     app: Any = None,
     validate_schema: bool = True,
@@ -38,6 +39,7 @@ def from_path(
             method=method,
             endpoint=endpoint,
             tag=tag,
+            operation_id=operation_id,
             app=app,
             validate_schema=validate_schema,
         )
@@ -49,6 +51,7 @@ def from_uri(
     method: Optional[Filter] = None,
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     *,
     app: Any = None,
     validate_schema: bool = True,
@@ -70,6 +73,7 @@ def from_uri(
         method=method,
         endpoint=endpoint,
         tag=tag,
+        operation_id=operation_id,
         app=app,
         validate_schema=validate_schema,
     )
@@ -82,6 +86,7 @@ def from_file(
     method: Optional[Filter] = None,
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     *,
     app: Any = None,
     validate_schema: bool = True,
@@ -99,6 +104,7 @@ def from_file(
         method=method,
         endpoint=endpoint,
         tag=tag,
+        operation_id=operation_id,
         app=app,
         validate_schema=validate_schema,
     )
@@ -111,6 +117,7 @@ def from_dict(
     method: Optional[Filter] = None,
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     *,
     app: Any = None,
     validate_schema: bool = True,
@@ -126,6 +133,7 @@ def from_dict(
             method=method,
             endpoint=endpoint,
             tag=tag,
+            operation_id=operation_id,
             app=app,
             validate_schema=validate_schema,
         )
@@ -139,6 +147,7 @@ def from_dict(
             method=method,
             endpoint=endpoint,
             tag=tag,
+            operation_id=operation_id,
             app=app,
             validate_schema=validate_schema,
         )
@@ -158,10 +167,18 @@ def from_pytest_fixture(
     method: Optional[Filter] = NOT_SET,
     endpoint: Optional[Filter] = NOT_SET,
     tag: Optional[Filter] = NOT_SET,
+    operation_id: Optional[Filter] = NOT_SET,
     validate_schema: bool = True,
 ) -> LazySchema:
     """Needed for a consistent library API."""
-    return LazySchema(fixture_name, method=method, endpoint=endpoint, tag=tag, validate_schema=validate_schema)
+    return LazySchema(
+        fixture_name,
+        method=method,
+        endpoint=endpoint,
+        tag=tag,
+        operation_id=operation_id,
+        validate_schema=validate_schema,
+    )
 
 
 def from_wsgi(
@@ -171,6 +188,7 @@ def from_wsgi(
     method: Optional[Filter] = None,
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     validate_schema: bool = True,
     **kwargs: Any,
 ) -> BaseSchema:
@@ -188,6 +206,7 @@ def from_wsgi(
         method=method,
         endpoint=endpoint,
         tag=tag,
+        operation_id=operation_id,
         app=app,
         validate_schema=validate_schema,
     )
@@ -206,6 +225,7 @@ def from_aiohttp(
     method: Optional[Filter] = None,
     endpoint: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     *,
     validate_schema: bool = True,
     **kwargs: Any,
@@ -218,5 +238,12 @@ def from_aiohttp(
     if not base_url:
         base_url = app_url
     return from_uri(
-        url, base_url=base_url, method=method, endpoint=endpoint, tag=tag, validate_schema=validate_schema, **kwargs
+        url,
+        base_url=base_url,
+        method=method,
+        endpoint=endpoint,
+        tag=tag,
+        operation_id=operation_id,
+        validate_schema=validate_schema,
+        **kwargs,
     )

--- a/test/data/simple_openapi.yaml
+++ b/test/data/simple_openapi.yaml
@@ -8,6 +8,7 @@ paths:
     get:
       summary: Returns a list of users.
       description: Optional extended description in Markdown.
+      operationId: users_get
       responses:
         "200":
           description: OK


### PR DESCRIPTION
trying to done  #546 
- schema.parametrize0 add new parameter `operationId`， `operationId` can is str or list
- when the schema is instantiated, a dict (schema.schema_map) record the mapping relationship between operationid and endpoint
- when call get_all_endpoints,  if has operationId than get endpoint from schema_map

