### PR TITLE
feat: Security parameters generation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,9 @@ Added
 
 - Display a suggestion to disable schema validation on schema loading errors in CLI. `#531`_
 - Filtration of endpoints by ``operationId`` via ``operation_id`` parameter to ``schema.parametrize`` or ``-O`` command-line option. `#546`_
+- Generation of security-related parameters. They are taken from ``securityDefinitions`` / ``securitySchemes`` and injected
+  to the generated data. It supports generating API keys in headers or query parameters and generating data for HTTP
+  authentication schemes as well. `#540`_
 
 `1.4.0`_ - 2020-05-03
 ---------------------
@@ -1015,6 +1018,7 @@ Fixed
 
 .. _#546: https://github.com/kiwicom/schemathesis/issues/546
 .. _#542: https://github.com/kiwicom/schemathesis/issues/542
+.. _#540: https://github.com/kiwicom/schemathesis/issues/540
 .. _#539: https://github.com/kiwicom/schemathesis/issues/539
 .. _#537: https://github.com/kiwicom/schemathesis/issues/537
 .. _#531: https://github.com/kiwicom/schemathesis/issues/531

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -10,6 +10,7 @@ from urllib.parse import quote_plus
 import hypothesis
 import hypothesis.strategies as st
 from hypothesis_jsonschema import from_schema
+from requests.auth import _basic_auth_str
 
 from . import utils
 from ._compat import handle_warnings
@@ -223,3 +224,9 @@ def register_string_format(name: str, strategy: st.SearchStrategy) -> None:
 def init_default_strategies() -> None:
     register_string_format("binary", st.binary())
     register_string_format("byte", st.binary().map(lambda x: b64encode(x).decode()))
+
+    def make_basic_auth_str(item: Tuple[str, str]) -> str:
+        return _basic_auth_str(*item)
+
+    register_string_format("_basic_auth", st.tuples(st.text(), st.text()).map(make_basic_auth_str))  # type: ignore
+    register_string_format("_bearer_auth", st.text().map("Bearer {}".format))

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -1,4 +1,5 @@
 import datetime
+from copy import deepcopy
 
 import pytest
 import yaml
@@ -129,6 +130,156 @@ def test_(case):
     )
     # Then the generated test case should contain it in its `form_data` attribute
     testdir.run_and_assert(passed=1)
+
+
+@pytest.fixture(params=["swagger", "openapi"])
+def schema_spec(request):
+    return request.param
+
+
+@pytest.fixture
+def base_schema(request, schema_spec):
+    if schema_spec == "swagger":
+        return deepcopy(request.getfixturevalue("simple_schema"))
+    if schema_spec == "openapi":
+        return deepcopy(request.getfixturevalue("simple_openapi"))
+
+
+@pytest.fixture(params=["header", "query"])
+def location(request):
+    return request.param
+
+
+@pytest.fixture
+def schema(schema_spec, location, base_schema):
+    # It is the same for Swagger & Open API
+    definition = {"api_key": {"type": "apiKey", "name": "api_key", "in": location}}
+    if schema_spec == "swagger":
+        base_schema["securityDefinitions"] = definition
+    if schema_spec == "openapi":
+        components = base_schema.setdefault("components", {})
+        components["securitySchemes"] = definition
+    base_schema["security"] = [{"api_key": []}]
+    return base_schema
+
+
+def test_security_definitions_api_key(testdir, schema, location):
+    # When schema contains "apiKeySecurity" security definition
+    # And it is in query or header
+    location = "headers" if location == "header" else location
+    testdir.make_test(
+        f"""
+@schema.parametrize()
+@settings(max_examples=1, deadline=None)
+def test_(case):
+    assert_str(case.{location}["api_key"])
+    assert_requests_call(case)
+        """,
+        schema=schema,
+    )
+    # Then the generated test case should contain API key in a proper place
+    testdir.run_and_assert(passed=1)
+
+
+def test_security_definitions_api_key_cookie(testdir, simple_openapi):
+    # When schema contains "apiKeySecurity" security definition
+    # And it is in cookie
+    schema = deepcopy(simple_openapi)
+    components = schema.setdefault("components", {})
+    components["securitySchemes"] = {"api_key": {"type": "apiKey", "name": "api_key", "in": "cookie"}}
+    schema["security"] = [{"api_key": []}]
+    testdir.make_test(
+        """
+@schema.parametrize()
+@settings(max_examples=1, deadline=None)
+def test_(case):
+    assert_str(case.cookies["api_key"])
+    assert_requests_call(case)
+        """,
+        schema=schema,
+    )
+    # Then the generated test case should contain API key in a proper place
+    testdir.run_and_assert(passed=1)
+
+
+@pytest.fixture()
+def overridden_security_schema(schema, schema_spec):
+    if schema_spec == "swagger":
+        schema["paths"]["/users"]["get"]["security"] = []
+    if schema_spec == "openapi":
+        schema["paths"]["/query"]["get"]["security"] = []
+    return schema
+
+
+def test_security_definitions_override(testdir, overridden_security_schema, location):
+    # When "security" is an empty list in the endpoint definition
+    testdir.make_test(
+        """
+@schema.parametrize()
+@settings(max_examples=1, deadline=None)
+def test_(case):
+    assert "api_key" not in (case.headers or [])
+    assert "api_key" not in (case.query or [])
+    assert_requests_call(case)
+        """,
+        schema=overridden_security_schema,
+    )
+    # Then the generated test case should not contain API key
+    testdir.run_and_assert(passed=1)
+
+
+@pytest.fixture()
+def basic_auth_schema(base_schema, schema_spec):
+    if schema_spec == "swagger":
+        base_schema["securityDefinitions"] = {"basic_auth": {"type": "basic"}}
+    if schema_spec == "openapi":
+        components = base_schema.setdefault("components", {})
+        components["securitySchemes"] = {"basic_auth": {"type": "http", "scheme": "basic"}}
+    base_schema["security"] = [{"basic_auth": []}]
+    return base_schema
+
+
+def test_security_definitions_basic_auth(testdir, basic_auth_schema):
+    # When schema is using HTTP Basic Auth
+    testdir.make_test(
+        """
+import base64
+
+@schema.parametrize()
+@settings(max_examples=1, deadline=None)
+def test_(case):
+    assert "Authorization" in case.headers
+    auth = case.headers["Authorization"]
+    assert auth.startswith("Basic ")
+    assert isinstance(base64.b64decode(auth[6:]), bytes)
+    assert_requests_call(case)
+        """,
+        schema=basic_auth_schema,
+    )
+    # Then the generated data should contain a valid "Authorization" header
+    testdir.run_and_assert(passed=1)
+
+
+def test_security_definitions_bearer_auth(testdir, simple_openapi):
+    # When schema is using HTTP Bearer Auth scheme
+    schema = deepcopy(simple_openapi)
+    components = schema.setdefault("components", {})
+    components["securitySchemes"] = {"bearer_auth": {"type": "http", "scheme": "bearer"}}
+    schema["security"] = [{"bearer_auth": []}]
+    testdir.make_test(
+        """
+@schema.parametrize()
+@settings(max_examples=1, deadline=None)
+def test_(case):
+    assert "Authorization" in case.headers
+    auth = case.headers["Authorization"]
+    assert auth.startswith("Bearer ")
+    assert_requests_call(case)
+        """,
+        schema=schema,
+    )
+    # Then the generated test case should contain a valid "Authorization" header
+    testdir.run_and_assert("-s", passed=1)
 
 
 def test_unknown_data(testdir):

--- a/test/test_petstore.py
+++ b/test/test_petstore.py
@@ -141,7 +141,7 @@ def test_(request, case):
     assert_requests_call(case)
 """
     )
-    testdir.assert_petstore(tests_num=1)
+    testdir.assert_petstore(tests_num=5)
 
 
 def test_create_order(testdir):


### PR DESCRIPTION
Resolves #540 

TODO:

- [x] Take definitions that are actually defined in the `security` key instead of taking everything defined
- [x] Filter for individual "security" definitions in endpoints (they may exclude some values)
- [x] Add "cookie" location for Open API 3.0
- [x] HTTP auth generation. E.g. we can generate valid `Authorization` header values depending on the defined schema (e.g. `Bearer` / `Basic` etc)

I discovered #559 during implementation - will fix it separately