### PR TITLE
feat: Add operationId filter to CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ The ``schemathesis`` command can be used to perform Schemathesis test cases:
 If your application requires authorization then you can use ``--auth`` option for Basic Auth and ``--header`` to specify
 custom headers to be sent with each request.
 
-To filter your tests by endpoint name, HTTP method or Open API tags you could use ``-E``, ``-M``, ``-T`` options respectively.
+To filter your tests by endpoint name, HTTP method, Open API tags or operationId you could use ``-E``, ``-M``, ``-T``, ``-O`` options respectively.
 
 CLI supports passing options to ``hypothesis.settings``. All of them are prefixed with ``--hypothesis-``:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Added
 ~~~~~
 
 - Display a suggestion to disable schema validation on schema loading errors in CLI. `#531`_
-- ``operation_id`` argument can get operations accurately by operationId . `#546`_
+- Filtration of endpoints by ``operationId`` via ``operation_id`` parameter to ``schema.parametrize`` or ``-O`` command-line option. `#546`_
 
 `1.4.0`_ - 2020-05-03
 ---------------------

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -123,6 +123,15 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
     callback=callbacks.validate_regex,
 )
 @click.option(
+    "--operation-id",
+    "-O",
+    "operation_ids",
+    type=str,
+    multiple=True,
+    help="Filter schemathesis test by operationId pattern.",
+    callback=callbacks.validate_regex,
+)
+@click.option(
     "--workers",
     "-w",
     "workers_num",
@@ -198,6 +207,7 @@ def run(  # pylint: disable=too-many-arguments
     endpoints: Optional[Filter] = None,
     methods: Optional[Filter] = None,
     tags: Optional[Filter] = None,
+    operation_ids: Optional[Filter] = None,
     workers_num: int = DEFAULT_WORKERS,
     base_url: Optional[str] = None,
     app: Optional[str] = None,
@@ -238,6 +248,7 @@ def run(  # pylint: disable=too-many-arguments
         endpoint=endpoints,
         method=methods,
         tag=tags,
+        operation_id=operation_ids,
         app=app,
         seed=hypothesis_seed,
         exit_first=exit_first,

--- a/src/schemathesis/filters.py
+++ b/src/schemathesis/filters.py
@@ -15,8 +15,7 @@ def should_skip_method(method: str, pattern: Optional[Filter]) -> bool:
 def should_skip_endpoint(endpoint: str, pattern: Optional[Filter]) -> bool:
     if pattern is None:
         return False
-    patterns = force_tuple(pattern)
-    return not any(re.search(item, endpoint) for item in patterns)
+    return not _match_any_pattern(endpoint, pattern)
 
 
 def should_skip_by_tag(tags: Optional[List[str]], pattern: Optional[Filter]) -> bool:
@@ -28,8 +27,14 @@ def should_skip_by_tag(tags: Optional[List[str]], pattern: Optional[Filter]) -> 
     return not any(re.search(item, tag) for item in patterns for tag in tags)
 
 
-def should_skip_by_operation_id(operation_id: str, pattern: Optional[Filter]) -> bool:
+def should_skip_by_operation_id(operation_id: Optional[str], pattern: Optional[Filter]) -> bool:
     if pattern is None:
         return False
+    if not operation_id:
+        return True
+    return not _match_any_pattern(operation_id, pattern)
+
+
+def _match_any_pattern(target: str, pattern: Filter) -> bool:
     patterns = force_tuple(pattern)
-    return not any(re.search(item, operation_id) for item in patterns)
+    return any(re.search(item, target) for item in patterns)

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -36,6 +36,7 @@ def prepare(  # pylint: disable=too-many-arguments
     endpoint: Optional[Filter] = None,
     method: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     app: Optional[str] = None,
     validate_schema: bool = True,
     # Hypothesis-specific configuration
@@ -71,6 +72,7 @@ def prepare(  # pylint: disable=too-many-arguments
         endpoint=endpoint,
         method=method,
         tag=tag,
+        operation_id=operation_id,
         app=app,
         validate_schema=validate_schema,
         checks=checks,
@@ -115,6 +117,7 @@ def execute_from_schema(
     endpoint: Optional[Filter] = None,
     method: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
     app: Optional[str] = None,
     validate_schema: bool = True,
     checks: Iterable[CheckFunction],
@@ -156,6 +159,7 @@ def execute_from_schema(
             endpoint=endpoint,
             method=method,
             tag=tag,
+            operation_id=operation_id,
         )
 
         runner: BaseRunner
@@ -236,9 +240,12 @@ def load_schema(
     endpoint: Optional[Filter] = None,
     method: Optional[Filter] = None,
     tag: Optional[Filter] = None,
+    operation_id: Optional[Filter] = None,
 ) -> BaseSchema:
     """Load schema via specified loader and parameters."""
-    loader_options = dict_true_values(base_url=base_url, endpoint=endpoint, method=method, tag=tag, app=app)
+    loader_options = dict_true_values(
+        base_url=base_url, endpoint=endpoint, method=method, tag=tag, operation_id=operation_id, app=app
+    )
 
     if not isinstance(schema_uri, dict):
         if file_exists(schema_uri):

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -177,6 +177,9 @@ def test_commands_run_help(cli):
         "  -T, --tag TEXT                  Filter schemathesis test by schema tag",
         "                                  pattern.",
         "",
+        "  -O, --operation-id TEXT         Filter schemathesis test by operationId",
+        "                                  pattern.",
+        "",
         "  -w, --workers INTEGER RANGE     Number of workers to run tests.",
         "  -b, --base-url TEXT             Base URL address of the API, required for",
         "                                  SCHEMA if specified by file.",
@@ -271,6 +274,7 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
         "endpoint": (),
         "method": (),
         "tag": (),
+        "operation_id": (),
         "schema_uri": SCHEMA_URI,
         "validate_schema": True,
         "loader": from_uri,
@@ -303,6 +307,7 @@ def test_execute_arguments(cli, mocker, simple_schema, args, expected):
         (["--method=POST", "--auth=test:test"], {"auth": ("test", "test"), "auth_type": "basic", "method": ("POST",)},),
         (["--endpoint=users"], {"endpoint": ("users",)}),
         (["--tag=foo"], {"tag": ("foo",)}),
+        (["--operation-id=getUser"], {"operation_id": ("getUser",)}),
         (["--base-url=https://example.com/api/v1test"], {"base_url": "https://example.com/api/v1test"}),
     ),
 )
@@ -321,6 +326,7 @@ def test_load_schema_arguments(cli, mocker, args, expected):
         "loader": from_uri,
         "method": (),
         "tag": (),
+        "operation_id": (),
         "validate_schema": True,
         **expected,
     }

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -51,6 +51,7 @@ def test_operation_id(operation_id):
             "/bar": {
                 "get": {**parameters, "operationId": "bar_get"},
                 "post": {**parameters, "operationId": "bar_post"},
+                "put": parameters,
             },
         },
     )


### PR DESCRIPTION
It also fixes the case when the filter is passed, but there is no `operationId` field defined (it was failing with `TypeError`)