### PR TITLE
fix: Reference resolving and `nullable` handling in response schema conformance check

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,7 @@ Fixed
 
 - Overriding header values in CLI and runner when headers provided explicitly clash with ones defined in the schema. `#559`_
 - Nested references resolving in ``response_schema_conformance`` check. `#562`_
+- Nullable parameters handling when they are behind a reference. `#542`_
 
 `1.4.0`_ - 2020-05-03
 ---------------------

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -213,7 +213,10 @@ COMMON_RESPONSES = {
                 "schema": {
                     "type": "object",
                     "additionalProperties": False,
-                    "properties": {"key": {"type": "string"}, "referenced": {"$ref": "attributes.yaml#/referenced"}},
+                    "properties": {
+                        "key": {"type": "string", "nullable": True},
+                        "referenced": {"$ref": "attributes.yaml#/referenced"},
+                    },
                     "required": ["key", "referenced"],
                 }
             }
@@ -221,7 +224,7 @@ COMMON_RESPONSES = {
     }
 }
 ATTRIBUTES = {"referenced": {"$ref": "attributes_nested.yaml#/nested_reference"}}
-ATTRIBUTES_NESTED = {"nested_reference": {"type": "string"}}
+ATTRIBUTES_NESTED = {"nested_reference": {"type": "string", "nullable": True}}
 
 
 @pytest.fixture()

--- a/test/runner/test_checks.py
+++ b/test/runner/test_checks.py
@@ -331,13 +331,14 @@ def test_response_schema_conformance_references_invalid(complex_schema):
 
 
 @pytest.mark.hypothesis_nested
-def test_response_schema_conformance_references_valid(complex_schema):
+@pytest.mark.parametrize("value", ("foo", None))
+def test_response_schema_conformance_references_valid(complex_schema, value):
     schema = schemathesis.from_path(complex_schema)
 
     @given(case=schema.endpoints["/teapot"]["POST"].as_strategy())
     @settings(max_examples=3)
     def test(case):
-        response = make_response(json.dumps({"key": "foo", "referenced": "foo"}).encode())
+        response = make_response(json.dumps({"key": value, "referenced": value}).encode())
         case.validate_response(response)
 
     test()

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -2,10 +2,11 @@ from copy import deepcopy
 from test.utils import as_param
 
 import pytest
-from jsonschema import RefResolver, ValidationError
+from jsonschema import ValidationError
 
 import schemathesis
 from schemathesis.exceptions import InvalidSchema
+from schemathesis.schemas import ConvertingResolver
 
 
 @pytest.mark.parametrize("base_path", ("/v1", "/v1/"))
@@ -45,13 +46,13 @@ def test_open_api_verbose_name(openapi_30):
 
 def test_resolver_cache(simple_schema, mocker):
     schema = schemathesis.from_dict(simple_schema)
-    spy = mocker.patch("schemathesis.schemas.jsonschema.RefResolver", wraps=RefResolver)
+    spy = mocker.patch("schemathesis.schemas.ConvertingResolver", wraps=ConvertingResolver)
     assert "_resolver" not in schema.__dict__
-    assert isinstance(schema.resolver, RefResolver)
+    assert isinstance(schema.resolver, ConvertingResolver)
     assert spy.call_count == 1
     # Cached
     assert "_resolver" in schema.__dict__
-    assert isinstance(schema.resolver, RefResolver)
+    assert isinstance(schema.resolver, ConvertingResolver)
     assert spy.call_count == 1
 
 


### PR DESCRIPTION
Fixes #542 

- [x] Comments & docstrings explaining why it is done this way
- [x] refactor nested resolver scoping - it could be a context manager
- [x] Refactor similar code in `_get_response_schema`
- [x] Refactor `traverse_schema` calls into a separate function (e.g. `to_jsons_chema_recursive`)
- [x] fix coverage