### PR TITLE
WIP: feat: Add generate_test_per_endpoint hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ Session.vim
 .netrwhist
 *~
 
+#####=== VS Code ===#####
+.vscode/*
+
 #####=== JetBrains ===#####
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
 

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -213,6 +213,11 @@ def before_generate_form_data(context: HookContext, strategy: st.SearchStrategy)
 
 
 @all_scopes
+def generate_test_per_endpoint(context: HookContext, strategy: st.SearchStrategy) -> st.SearchStrategy:
+    """Creates an additional test for user to modify."""
+
+
+@all_scopes
 def before_process_path(context: HookContext, path: str, methods: Dict[str, Any]) -> None:
     """Called before API path is processed."""
 

--- a/src/schemathesis/runner/impl/threadpool.py
+++ b/src/schemathesis/runner/impl/threadpool.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, cas
 import attr
 import hypothesis
 
-from ..._hypothesis import make_test_or_exception
+from ..._hypothesis import make_tests_or_exception
 from ...models import CheckFunction, TestResultSet
 from ...types import RawAuth
 from ...utils import capture_hypothesis_output, get_requests_auth
@@ -31,9 +31,9 @@ def _run_task(
     with capture_hypothesis_output():
         while not tasks_queue.empty():
             endpoint = tasks_queue.get()
-            test = make_test_or_exception(endpoint, test_template, settings, seed)
-            for event in run_test(endpoint, test, checks, targets, results, **kwargs):
-                events_queue.put(event)
+            for test in make_tests_or_exception(endpoint, test_template, settings, seed):
+                for event in run_test(endpoint, test, checks, targets, results, **kwargs):
+                    events_queue.put(event)
 
 
 def thread_task(

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -14,7 +14,7 @@ import attr
 import hypothesis
 from requests.structures import CaseInsensitiveDict
 
-from ._hypothesis import make_test_or_exception
+from ._hypothesis import make_tests_or_exception
 from .exceptions import InvalidSchema
 from .hooks import HookContext, HookDispatcher, HookLocation, HookScope, dispatch, warn_deprecated_hook
 from .models import Endpoint
@@ -64,10 +64,9 @@ class BaseSchema(Mapping):
         self, func: Callable, settings: Optional[hypothesis.settings] = None, seed: Optional[int] = None
     ) -> Generator[Tuple[Endpoint, Union[Callable, InvalidSchema]], None, None]:
         """Generate all endpoints and Hypothesis tests for them."""
-        test: Union[Callable, InvalidSchema]
         for endpoint in self.get_all_endpoints():
-            test = make_test_or_exception(endpoint, func, settings, seed)
-            yield endpoint, test
+            for test in make_tests_or_exception(endpoint, func, settings, seed):
+                yield endpoint, test
 
     def parametrize(  # pylint: disable=too-many-arguments
         self,


### PR DESCRIPTION
Related issue: #458 

This initial PR is a proof of concept and is ready for discussion.

This solution adds a `before_one` hook. This hook adds a test to the test suite for each `before_one` hook defined. Each `before_one` hook receives one of the strategies from one of the additional tests. The hook may update this strategy before a request is sent to the server. Since each strategy produces data that is valid against the schema, it allows the user to alter an otherwise valid strategy to produce requests that target specific behavior of the server.

Additional Questions and Needs:
- Tests
- Does this implementation duplicate requests generated from an example (i.e. `--hypothesis-phases=explicit`)? Because an example request is (in my experience) the best representation of a valid request, I would like the duplicated tests to come from examples if they exist and randomly generated, valid data otherwise.
- Is the `GLOBAL` scope appropriate for this hook?
- Is it OK that we have to get the `before_one` hooks in two places (threadpool.py and schemas.py)?

