### PR TITLE
test: Fix build for pytest<5.4

### DIFF
--- a/test/cli/test_junitxml.py
+++ b/test/cli/test_junitxml.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree
 
 import pytest
-from _pytest.config import ExitCode
+from _pytest.main import ExitCode
 
 
 @pytest.mark.endpoints("success")

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
 commands =
   coverage run --source=schemathesis -m pytest {posargs:} test
 
-[testenv:pytest53]
+[testenv:py3-pytest53]
 deps =
   aiohttp
   flask


### PR DESCRIPTION
This job was installing pytest 5.4.1 instead of the latest one from `5.3.x` 