### PR TITLE
fix: Display proper headers in reproduction code when headers are overridden

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Display proper headers in reproduction code when headers are overridden. `#566`_
+
 `1.5.0`_ - 2020-05-06
 ---------------------
 
@@ -1026,6 +1031,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#566: https://github.com/kiwicom/schemathesis/issues/566
 .. _#562: https://github.com/kiwicom/schemathesis/issues/562
 .. _#559: https://github.com/kiwicom/schemathesis/issues/559
 .. _#546: https://github.com/kiwicom/schemathesis/issues/546

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -60,10 +60,14 @@ class Case:
         except KeyError:
             raise InvalidSchema("Missing required property `required: true`")
 
-    def get_code_to_reproduce(self) -> str:
+    def get_code_to_reproduce(self, headers: Optional[Dict[str, Any]] = None) -> str:
         """Construct a Python code to reproduce this case with `requests`."""
         base_url = self.base_url or "http://localhost"
         kwargs = self.as_requests_kwargs(base_url)
+        if headers:
+            final_headers = kwargs["headers"] or {}
+            final_headers.update(headers)
+            kwargs["headers"] = final_headers
         method = kwargs["method"].lower()
 
         def are_defaults(key: str, value: Optional[Dict]) -> bool:
@@ -398,6 +402,8 @@ class TestResult:
     logs: List[LogRecord] = attr.ib(factory=list)  # pragma: no mutate
     is_errored: bool = attr.ib(default=False)  # pragma: no mutate
     seed: Optional[int] = attr.ib(default=None)  # pragma: no mutate
+    # To show a proper reproduction code if a failure happens
+    overridden_headers: Optional[Dict[str, Any]] = attr.ib(default=None)  # pragma: no mutate
 
     def mark_errored(self) -> None:
         self.is_errored = True

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -70,11 +70,12 @@ def run_test(
     checks: Iterable[CheckFunction],
     targets: Iterable[Target],
     results: TestResultSet,
+    headers: Optional[Dict[str, Any]],
     **kwargs: Any,
 ) -> Generator[events.ExecutionEvent, None, None]:
     """A single test run with all error handling needed."""
     # pylint: disable=too-many-arguments
-    result = TestResult(endpoint=endpoint)
+    result = TestResult(endpoint=endpoint, overridden_headers=headers)
     yield events.BeforeExecution.from_endpoint(endpoint=endpoint)
     hypothesis_output: List[str] = []
     test_start_time = time.monotonic()
@@ -84,7 +85,7 @@ def run_test(
             result.add_error(test)
         else:
             with capture_hypothesis_output() as hypothesis_output:
-                test(checks, targets, result, **kwargs)
+                test(checks, targets, result, headers=headers, **kwargs)
             status = Status.success
     except (AssertionError, hypothesis.errors.MultipleFailures):
         status = Status.failure


### PR DESCRIPTION
Resolves #566