### PR TITLE
fix: Base URL handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,11 +380,11 @@ For convenience you can explore the schemas and strategies manually:
 
     >>> import schemathesis
     >>> schema = schemathesis.from_uri("http://0.0.0.0:8080/petstore.json")
-    >>> endpoint = schema["/v2/pet"]["POST"]
+    >>> endpoint = schema["/pet"]["POST"]
     >>> strategy = endpoint.as_strategy()
     >>> strategy.example()
     Case(
-        path='/v2/pet',
+        path='/pet',
         method='POST',
         path_parameters={},
         headers={},
@@ -398,6 +398,14 @@ For convenience you can explore the schemas and strategies manually:
     )
 
 Schema instances implement ``Mapping`` protocol.
+
+**NOTE**. Paths are relative to the schema's base path (``host`` + ``basePath`` in Open API 2.0 and ``server.url`` in Open API 3.0):
+
+.. code:: python
+
+    # your ``basePath`` is ``/api/v1``
+    >>> schema["/pet"]["POST"]  # VALID
+    >>> schema["/api/v1/pet"]["POST"]  # INVALID
 
 Lazy loading
 ~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,36 @@ Changelog
 `Unreleased`_
 -------------
 
+Changed
+~~~~~~~
+
+- **BREAKING**. Base URL handling. ``base_url`` now is treated as one with a base path included.
+  You should pass a full base URL now instead:
+
+.. code:: bash
+
+    schemathesis run --base-url=http://127.0.0.1:8080/api/v2 ...
+
+This value will override ``basePath`` / ``servers[0].url`` defined in your schema if you use
+Open API 2.0 / 3.0 respectively. Previously if you pass a base URL like the one above it
+was concatenated with the base path defined in the schema which lead to lack of ability
+to redefine the base path. `#511`_
+
+Fixed
+~~~~~
+
+- Show correct URL in CLI progress when base URL is overridden including the path part. `#511`_
+- Construct valid URL when overriding base URL with base path. `#511`_
+
+**Example**:
+
+.. code:: bash
+
+    Base URL in the schema         : http://0.0.0.0:8081/api/v1
+    `--base-url` value in CLI      : http://0.0.0.0:8081/api/v2
+    Full URLs before this change   : http://0.0.0.0:8081/api/v2/api/v1/users/  # INVALID!
+    Full URLs after  this change   : http://0.0.0.0:8081/api/v2/users/         # VALID!
+
 `1.10.0`_ - 2020-06-28
 ---------------------
 
@@ -1196,6 +1226,7 @@ Fixed
 .. _#519: https://github.com/kiwicom/schemathesis/issues/519
 .. _#513: https://github.com/kiwicom/schemathesis/issues/513
 .. _#512: https://github.com/kiwicom/schemathesis/issues/512
+.. _#511: https://github.com/kiwicom/schemathesis/issues/511
 .. _#504: https://github.com/kiwicom/schemathesis/issues/504
 .. _#503: https://github.com/kiwicom/schemathesis/issues/503
 .. _#499: https://github.com/kiwicom/schemathesis/issues/499

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -150,3 +150,29 @@ This command will create an XML at given path as in example below.
             <testcase name="GET /api/success" time="0.006397"/>
         </testsuite>
     </testsuites>
+
+
+Base URL configuration
+----------------------
+
+If your Open API schema defines ``servers`` (or ``basePath`` in Open API 2.0), then these values will be used to
+construct full endpoint URL during testing. In case of Open API 3.0 the first value from ``servers`` will be used.
+
+However, you may want to run tests against a different base URL. To do this you need to pass ``--base-url`` option in CLI
+or provide ``base_url`` argument to a loader / runner if you use Schemathesis in your code:
+
+.. code:: bash
+
+    schemathesis run --base-url=http://127.0.0.1:8080/api/v2 http://production.com/api/openapi.json
+
+And if your schema defines ``servers`` like this
+
+.. code:: yaml
+
+    servers:
+      - url: https://production.com/api/{basePath}
+        variables:
+          basePath:
+            default: v1
+
+Then the tests will be executed against ``/api/v2`` base path.

--- a/src/schemathesis/extra/pytest_plugin.py
+++ b/src/schemathesis/extra/pytest_plugin.py
@@ -31,7 +31,7 @@ class SchemathesisCase(PyCollector):
         super().__init__(*args, **kwargs)
 
     def _get_test_name(self, endpoint: Endpoint) -> str:
-        return f"{self.name}[{endpoint.method}:{endpoint.path}]"
+        return f"{self.name}[{endpoint.method}:{endpoint.full_path}]"
 
     def _gen_items(self, endpoint: Endpoint) -> Generator[Function, None, None]:
         """Generate all items for the given endpoint.

--- a/src/schemathesis/lazy.py
+++ b/src/schemathesis/lazy.py
@@ -88,8 +88,8 @@ def get_test(test: Union[Callable, InvalidSchema]) -> Callable:
 
 
 def _get_node_name(node_id: str, endpoint: Endpoint) -> str:
-    """Make a test node name. For example: test_api[GET:/v1/users]."""
-    return f"{node_id}[{endpoint.method}:{endpoint.path}]"
+    """Make a test node name. For example: test_api[GET:/users]."""
+    return f"{node_id}[{endpoint.method}:{endpoint.full_path}]"
 
 
 def run_subtest(endpoint: Endpoint, fixtures: Dict[str, Any], sub_test: Callable, subtests: SubTests) -> None:

--- a/src/schemathesis/loaders.py
+++ b/src/schemathesis/loaders.py
@@ -18,7 +18,7 @@ from .lazy import LazySchema
 from .specs.openapi import definitions
 from .specs.openapi.schemas import BaseOpenAPISchema, OpenApi30, SwaggerV20
 from .types import Filter, PathLike
-from .utils import NOT_SET, StringDatesYAMLLoader, WSGIResponse, get_base_url
+from .utils import NOT_SET, StringDatesYAMLLoader, WSGIResponse
 
 
 def from_path(
@@ -66,8 +66,6 @@ def from_uri(
         response.raise_for_status()
     except requests.HTTPError:
         raise HTTPError(response=response, url=uri)
-    if base_url is None:
-        base_url = get_base_url(uri)
     return from_file(
         response.text,
         location=uri,
@@ -239,8 +237,6 @@ def from_aiohttp(
     port = run_server(app)
     app_url = f"http://127.0.0.1:{port}/"
     url = urljoin(app_url, schema_path)
-    if not base_url:
-        base_url = app_url
     return from_uri(
         url,
         base_url=base_url,

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -10,7 +10,7 @@ from ..checks import DEFAULT_CHECKS
 from ..models import CheckFunction
 from ..schemas import BaseSchema
 from ..types import Filter, NotSet, RawAuth
-from ..utils import dict_not_none_values, dict_true_values, file_exists, get_base_url, get_requests_auth, import_app
+from ..utils import dict_not_none_values, dict_true_values, file_exists, get_requests_auth, import_app
 from . import events
 from .impl import (
     DEFAULT_STATEFUL_RECURSION_LIMIT,
@@ -316,8 +316,6 @@ def load_schema(
         else:
             loader_options.update(dict_true_values(headers=headers, auth=auth, auth_type=auth_type))
 
-    if "base_url" not in loader_options and not isinstance(schema_uri, dict):
-        loader_options["base_url"] = get_base_url(schema_uri)
     if loader is loaders.from_uri and loader_options.get("auth"):
         loader_options["auth"] = get_requests_auth(loader_options["auth"], loader_options.pop("auth_type", None))
 

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -35,7 +35,7 @@ class Initialized(ExecutionEvent):
         return cls(
             endpoints_count=schema.endpoints_count,
             location=schema.location,
-            base_url=schema.base_url,
+            base_url=schema.get_base_url(),
             specification_name=schema.verbose_name,
         )
 
@@ -53,7 +53,7 @@ class BeforeExecution(ExecutionEvent):
 
     @classmethod
     def from_endpoint(cls, endpoint: Endpoint, recursion_level: int) -> "BeforeExecution":
-        return cls(method=endpoint.method, path=endpoint.path, recursion_level=recursion_level)
+        return cls(method=endpoint.method, path=endpoint.full_path, recursion_level=recursion_level)
 
 
 @attr.s(slots=True)  # pragma: no mutate

--- a/src/schemathesis/runner/serialization.py
+++ b/src/schemathesis/runner/serialization.py
@@ -89,7 +89,7 @@ class SerializedTestResult:
         formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
         return SerializedTestResult(
             method=result.endpoint.method,
-            path=result.endpoint.path,
+            path=result.endpoint.full_path,
             has_failures=result.has_failures,
             has_errors=result.has_errors,
             has_logs=result.has_logs,

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -7,7 +7,6 @@ import warnings
 from contextlib import contextmanager
 from functools import wraps
 from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Type, Union, overload
-from urllib.parse import urlsplit, urlunsplit
 
 import requests
 import yaml
@@ -83,12 +82,6 @@ def is_schemathesis_test(func: Callable) -> bool:
         return isinstance(item, BaseSchema)
     except Exception:
         return False
-
-
-def get_base_url(uri: str) -> str:
-    """Remove the path part off the given uri."""
-    parts = urlsplit(uri)[:2] + ("", "", "")
-    return urlunsplit(parts)
 
 
 def force_tuple(item: Filter) -> Union[List, Set, Tuple]:

--- a/test/apps/_aiohttp/__init__.py
+++ b/test/apps/_aiohttp/__init__.py
@@ -50,7 +50,7 @@ def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> web.Appli
 
     app = web.Application()
     app.add_routes(
-        [web.get("/swagger.yaml", schema), web.get("/cookies", set_cookies)]
+        [web.get("/swagger.yaml", schema), web.get("/api/cookies", set_cookies)]
         + [web.route(item.value[0], item.value[1], wrapper(item.name)) for item in Endpoint]
     )
     app["users"] = {}

--- a/test/cli/output/test_default.py
+++ b/test/cli/output/test_default.py
@@ -176,7 +176,7 @@ def test_display_single_failure(capsys, swagger_20, execution_context, endpoint,
     out = capsys.readouterr().out
     lines = out.split("\n")
     # Then the endpoint name is displayed as a subsection
-    assert " GET: /success " in lines[0]
+    assert " GET: /v1/success " in lines[0]
     # And check name is displayed in red
     assert lines[1] == strip_style_win32(click.style("Check           : not_a_server_error", fg="red"))
     # And body should be displayed if it is not None
@@ -268,7 +268,7 @@ def test_display_failures(swagger_20, capsys, execution_context, results_set):
     # Then section title is displayed
     assert " FAILURES " in out
     # And endpoint with a failure is displayed as a subsection
-    assert " GET: /api/failure " in out
+    assert " GET: /v1/api/failure " in out
     assert "Message" in out
     # And check name is displayed
     assert "Check           : test" in out
@@ -299,7 +299,7 @@ def test_display_errors(swagger_20, capsys, results_set, execution_context, show
     # And help message is displayed only if tracebacks are not shown
     assert help_message_exists is not show_errors_tracebacks
     # And endpoint with an error is displayed as a subsection
-    assert " GET: /api/error " in out
+    assert " GET: /v1/api/error " in out
     # And the error itself is displayed
     assert "ConnectionError: Connection refused!" in out
     # And the example is displayed

--- a/test/cli/test_cassettes.py
+++ b/test/cli/test_cassettes.py
@@ -105,7 +105,7 @@ async def test_replay(cli, schema_url, app, reset_app, cassette_path):
 
 
 def test_multiple_cookies(base_url):
-    response = requests.get(f"{base_url}/api/success", cookies={"foo": "bar", "baz": "spam"})
+    response = requests.get(f"{base_url}/success", cookies={"foo": "bar", "baz": "spam"})
     request = Request.from_prepared_request(response.request)
     serialized = {
         "uri": request.uri,

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -477,7 +477,7 @@ def test_cli_run_output_empty(cli, cli_args, workers):
 @pytest.mark.parametrize("workers", (1, 2))
 def test_cli_run_changed_base_url(cli, server, cli_args, workers):
     # When the CLI receives custom base URL
-    base_url = f"http://127.0.0.1:{server['port']}/api/"
+    base_url = f"http://127.0.0.1:{server['port']}/api"
     result = cli.run(*cli_args, "--base-url", base_url, f"--workers={workers}")
     # Then the base URL should be correctly displayed in the CLI output
     lines = result.stdout.strip().split("\n")
@@ -487,8 +487,8 @@ def test_cli_run_changed_base_url(cli, server, cli_args, workers):
 @pytest.mark.parametrize(
     "url, message",
     (
-        ("/api/doesnt_exist", f"Schema was not found at http://127.0.0.1"),
-        ("/api/failure", f"Failed to load schema, code 500 was returned from http://127.0.0.1"),
+        ("/doesnt_exist", f"Schema was not found at http://127.0.0.1"),
+        ("/failure", f"Failed to load schema, code 500 was returned from http://127.0.0.1"),
     ),
 )
 @pytest.mark.endpoints("failure")
@@ -714,7 +714,7 @@ def test_multiple_failures_different_check(cli, schema_url):
 @pytest.mark.parametrize("workers", (1, 2))
 def test_connection_error(cli, schema_url, workers):
     # When the given base_url is unreachable
-    result = cli.run(schema_url, "--base-url=http://127.0.0.1:1/", f"--workers={workers}")
+    result = cli.run(schema_url, "--base-url=http://127.0.0.1:1/api", f"--workers={workers}")
     # Then the whole Schemathesis run should fail
     assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
     # And all collected endpoints should be marked as errored

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,7 +10,7 @@ from schemathesis.extra._aiohttp import run_server as run_aiohttp_server
 from schemathesis.extra._flask import run_server as run_flask_server
 
 from .apps import Endpoint, _aiohttp, _fastapi, _flask, _graphql
-from .utils import make_schema
+from .utils import get_schema_path, make_schema
 
 pytest_plugins = ["pytester", "aiohttp.pytest_plugin", "pytest_mock"]
 
@@ -72,13 +72,13 @@ def server(_app):
 @pytest.fixture()
 def base_url(server, app):
     """Base URL for the running application."""
-    return f"http://127.0.0.1:{server['port']}"
+    return f"http://127.0.0.1:{server['port']}/api"
 
 
 @pytest.fixture()
-def schema_url(base_url):
+def schema_url(server, app):
     """URL of the schema of the running application."""
-    return f"{base_url}/swagger.yaml"
+    return f"http://127.0.0.1:{server['port']}/swagger.yaml"
 
 
 @pytest.fixture(scope="session")
@@ -297,6 +297,11 @@ def complex_schema(testdir):
     (common / "attributes.yaml").write_text(yaml.dump(ATTRIBUTES), "utf8")
     (common / "attributes_nested.yaml").write_text(yaml.dump(ATTRIBUTES_NESTED), "utf8")
     return str(root)
+
+
+@pytest.fixture(name="get_schema_path")
+def _get_schema_path():
+    return get_schema_path
 
 
 @pytest.fixture()

--- a/test/generation/test_primitive.py
+++ b/test/generation/test_primitive.py
@@ -30,7 +30,7 @@ validator = {{
 @schema.parametrize()
 @settings(max_examples=3)
 def test_(case):
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method in ("GET", "POST")
     validator(case.query["{name}"])
         """.format(
@@ -76,7 +76,7 @@ validator = {{
 @schema.parametrize()
 @settings(max_examples=3)
 def test_(case):
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "GET"
     validator(case.query["{name}"])
         """.format(

--- a/test/hooks/test_deprecated.py
+++ b/test/hooks/test_deprecated.py
@@ -25,7 +25,7 @@ def schema(flask_app):
 @pytest.mark.endpoints("custom_format")
 @pytest.mark.usefixtures("query_hook")
 def test_global_query_hook(schema, schema_url):
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -39,7 +39,7 @@ def test_global_query_hook(schema, schema_url):
 @pytest.mark.endpoints("custom_format")
 def test_schema_query_hook(schema, schema_url):
     schema.register_hook("query", hook)
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -54,11 +54,11 @@ def test_schema_query_hook(schema, schema_url):
 @pytest.mark.endpoints("custom_format")
 def test_hooks_combination(schema, schema_url):
     def extra(context, st):
-        assert context.endpoint == schema.endpoints["/api/custom_format"]["GET"]
+        assert context.endpoint == schema.endpoints["/custom_format"]["GET"]
         return st.filter(lambda x: int(x["id"]) % 2 == 0)
 
     schema.register_hook("query", extra)
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -168,7 +168,7 @@ def test_deprecated_hook(recwarn, schema):
         "support will be removed in Schemathesis 2.0."
     )
 
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)

--- a/test/hooks/test_hooks.py
+++ b/test/hooks/test_hooks.py
@@ -37,7 +37,7 @@ def dispatcher():
 @pytest.mark.endpoints("custom_format")
 @pytest.mark.usefixtures("global_hook")
 def test_global_query_hook(schema, schema_url):
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -54,7 +54,7 @@ def test_schema_query_hook(schema, schema_url):
     def before_generate_query(context, strategy):
         return strategy.filter(lambda x: x["id"].isdigit())
 
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -70,10 +70,10 @@ def test_schema_query_hook(schema, schema_url):
 def test_hooks_combination(schema, schema_url):
     @schema.hooks.register("before_generate_query")
     def extra(context, st):
-        assert context.endpoint == schema.endpoints["/api/custom_format"]["GET"]
+        assert context.endpoint == schema.endpoints["/custom_format"]["GET"]
         return st.filter(lambda x: int(x["id"]) % 2 == 0)
 
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -224,7 +224,7 @@ def test_multiple_hooks_per_spec(schema):
 
     assert schema.hooks.get_all_by_name("before_generate_query") == [first_hook, second_hook]
 
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)
@@ -243,7 +243,7 @@ def test_before_process_path_hook(schema):
         methods["get"]["parameters"][0]["name"] = "foo"
         methods["get"]["parameters"][0]["const"] = "bar"
 
-    strategy = schema.endpoints["/api/custom_format"]["GET"].as_strategy()
+    strategy = schema.endpoints["/custom_format"]["GET"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3)

--- a/test/specs/openapi/test_links.py
+++ b/test/specs/openapi/test_links.py
@@ -10,7 +10,7 @@ from schemathesis.specs.openapi.links import Link
 from schemathesis.stateful import ParsedData
 
 ENDPOINT = Endpoint(
-    path="/api/users/{user_id}",
+    path="/users/{user_id}",
     method="GET",
     definition=ANY,
     schema=ANY,
@@ -57,7 +57,7 @@ def response():
     "url, expected",
     (
         (
-            "/api/users/",
+            "/users/",
             [
                 LINK,
                 Link(
@@ -75,7 +75,7 @@ def response():
 def test_get_links(base_url, schema_url, url, expected):
     schema = schemathesis.from_uri(schema_url)
     response = requests.post(f"{base_url}{url}", json={"username": "TEST"})
-    assert schema.endpoints["/api/users/"]["POST"].get_stateful_tests(response, "links") == expected
+    assert schema.endpoints["/users/"]["POST"].get_stateful_tests(response, "links") == expected
 
 
 def test_parse(case, response):
@@ -185,7 +185,5 @@ def test_make_endpoint_single():
 
 @pytest.mark.parametrize("parameter", ("wrong.id", "unknown", "header.id"))
 def test_make_endpoint_invalid_location(parameter):
-    with pytest.raises(
-        ValueError, match=f"Parameter `{parameter}` is not defined in endpoint GET /api/users/{{user_id}}"
-    ):
+    with pytest.raises(ValueError, match=f"Parameter `{parameter}` is not defined in endpoint GET /users/{{user_id}}"):
         LINK.make_endpoint([ParsedData({parameter: 4})])

--- a/test/specs/openapi/test_schemas.py
+++ b/test/specs/openapi/test_schemas.py
@@ -7,7 +7,7 @@ from schemathesis.models import Endpoint
 def test_get_endpoint_via_remote_reference(swagger_20, schema_url):
     resolved = swagger_20.get_endpoint_by_reference(f"{schema_url}#/paths/~1users~1{{user_id}}/patch")
     assert isinstance(resolved, Endpoint)
-    assert resolved.path == "/v1/users/{user_id}"
+    assert resolved.path == "/users/{user_id}"
     assert resolved.method == "PATCH"
     # Via common parameters for all methods
     assert resolved.query == {

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -19,7 +19,7 @@ async def func():
 {"@pytest.mark.asyncio" if plugin == "pytest_asyncio" else ""}
 async def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method == "GET"
     assert await func() == 1
 """,
@@ -41,7 +41,7 @@ def test_settings_first(testdir, plugin):
 @settings(max_examples=5)
 async def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method in ("GET", "POST")
 """,
         pytest_plugins=[plugin],
@@ -82,7 +82,7 @@ def app():
 async def test_(request, aiohttp_client, app, case):
     request.config.HYPOTHESIS_CASES += 1
     client = await aiohttp_client(app)
-    response = await client.request(case.method, case.formatted_path, headers=case.headers, json=case.body)
+    response = await client.request(case.method, f"/v1{case.formatted_path}", headers=case.headers, json=case.body)
     assert response.status < 500
     assert len(app["saved_requests"]) == 1
     assert app["saved_requests"][0].method == "GET"

--- a/test/test_common_parameters.py
+++ b/test/test_common_parameters.py
@@ -9,7 +9,7 @@ def test_common_parameters(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method in ["GET", "POST"]
     assert_int(case.query["common_id"])
     assert_int(case.query["not_common_id"])
@@ -42,7 +42,7 @@ def test_common_parameters_with_references(testdir):
         """
 def impl(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/foo"
+    assert case.full_path == "/v1/foo"
     assert case.method in ["PUT", "POST"]
     if case.method == "POST":
         assert_int(case.body)
@@ -88,7 +88,7 @@ def test_common_parameters_multiple_tests(testdir):
         """
 def impl(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method in ["GET", "POST"]
     assert_int(case.query["common_id"])
 

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -128,7 +128,7 @@ def test_simple_dereference(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     assert_int(case.body)
 """,
@@ -163,7 +163,7 @@ def test_recursive_dereference(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     assert_int(case.body["id"])
 """,
@@ -206,7 +206,7 @@ def test_inner_dereference(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     assert_int(case.body["id"])
 """,
@@ -245,7 +245,7 @@ def test_inner_dereference_with_lists(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     assert_int(case.body["id"]["a"])
     assert_str(case.body["id"]["b"])
@@ -351,7 +351,7 @@ def test_nullable_parameters(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "GET"
     assert case.query["id"] is None
 """,
@@ -369,7 +369,7 @@ def test_nullable_properties(testdir):
 @schema.parametrize(method="POST")
 @settings(max_examples=10)
 def test_(request, case):
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     if case.body["id"] is None:
         request.config.HYPOTHESIS_CASES += 1
@@ -409,7 +409,7 @@ def test_nullable_ref(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     assert case.body is None
 """,
@@ -444,7 +444,7 @@ def test_path_ref(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert isinstance(case.body, str)
 """,
         paths={"/users": {"$ref": "#/x-paths/UsersPath"}},
@@ -473,7 +473,7 @@ def test_nullable_enum(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "GET"
     assert case.query["id"] is None
 """,
@@ -489,6 +489,7 @@ def test_complex_dereference(testdir, complex_schema):
     schema = schemathesis.from_path(complex_schema)
     path = Path(str(testdir))
     assert schema.endpoints["/teapot"]["POST"] == Endpoint(
+        base_url="file:///",
         path="/teapot",
         method="POST",
         definition=EndpointDefinition(

--- a/test/test_direct_access.py
+++ b/test/test_direct_access.py
@@ -8,18 +8,18 @@ from schemathesis.specs.openapi.schemas import endpoints_to_dict
 
 
 def test_contains(swagger_20):
-    assert "/v1/users" in swagger_20
+    assert "/users" in swagger_20
 
 
 def test_getitem(simple_schema, mocker):
     swagger = schemathesis.from_dict(simple_schema)
     mocked = mocker.patch("schemathesis.specs.openapi.schemas.endpoints_to_dict", wraps=endpoints_to_dict)
     assert "_endpoints" not in swagger.__dict__
-    assert isinstance(swagger["/v1/users"], CaseInsensitiveDict)
+    assert isinstance(swagger["/users"], CaseInsensitiveDict)
     assert mocked.call_count == 1
     # Check cached access
     assert "_endpoints" in swagger.__dict__
-    assert isinstance(swagger["/v1/users"], CaseInsensitiveDict)
+    assert isinstance(swagger["/users"], CaseInsensitiveDict)
     assert mocked.call_count == 1
 
 
@@ -28,7 +28,7 @@ def test_len(swagger_20):
 
 
 def test_iter(swagger_20):
-    assert list(swagger_20) == ["/v1/users"]
+    assert list(swagger_20) == ["/users"]
 
 
 def test_repr(swagger_20):
@@ -37,12 +37,12 @@ def test_repr(swagger_20):
 
 @pytest.mark.parametrize("method", ("GET", "get"))
 def test_endpoint_access(swagger_20, method):
-    assert isinstance(swagger_20["/v1/users"][method], Endpoint)
+    assert isinstance(swagger_20["/users"][method], Endpoint)
 
 
 @pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
 def test_as_strategy(swagger_20):
-    endpoint = swagger_20["/v1/users"]["GET"]
+    endpoint = swagger_20["/users"]["GET"]
     strategy = endpoint.as_strategy()
     assert isinstance(strategy, st.SearchStrategy)
     assert strategy.example() == Case(endpoint)
@@ -69,5 +69,5 @@ def test_reference_in_path():
         },
     }
     schema = schemathesis.from_dict(raw_schema)
-    strategy = schema["/api/{key}"]["GET"].as_strategy()
+    strategy = schema["/{key}"]["GET"].as_strategy()
     assert isinstance(strategy.example().path_parameters["key"], str)

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -13,7 +13,7 @@ def test_endpoint_filter(testdir, endpoint):
 @settings(max_examples=5)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/foo"
+    assert case.full_path == "/v1/foo"
     assert case.method == "GET"
 """.format(
             endpoint
@@ -36,7 +36,7 @@ def test_method_filter(testdir, method):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path in ("/v1/foo", "/v1/users")
+    assert case.full_path in ("/v1/foo", "/v1/users")
     assert case.method == "GET"
 """.format(
             method
@@ -60,7 +60,7 @@ def test_tag_filter(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/bar"
+    assert case.full_path == "/v1/bar"
     assert case.method == "GET"
 """,
         paths={
@@ -82,7 +82,7 @@ def test_loader_filter(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/foo"
+    assert case.full_path == "/v1/foo"
     assert case.method == "POST"
 """,
         paths={
@@ -110,14 +110,14 @@ def test_override_filter(testdir):
 @settings(max_examples=1)
 def test_a(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method == "GET"
 
 @schema.parametrize(method=None, endpoint=None)
 @settings(max_examples=1)
 def test_b(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/foo"
+    assert case.full_path == "/v1/foo"
     assert case.method == "POST"
 """,
         paths={
@@ -146,7 +146,7 @@ def test_operation_id_filter(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/bar"
+    assert case.full_path == "/v1/bar"
     assert case.method == "GET"
 """,
         paths={
@@ -170,7 +170,7 @@ def test_operation_id_list_filter(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/foo"
+    assert case.full_path == "/v1/foo"
 """,
         paths={
             "/foo": {

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -13,7 +13,7 @@ lazy_schema = schemathesis.from_pytest_fixture("simple_schema")
 
 @lazy_schema.parametrize()
 def test_(case):
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method == "GET"
 """
     )
@@ -111,7 +111,7 @@ def another():
 @lazy_schema.parametrize()
 def test_(request, case, another):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method == "GET"
     assert another == 1
 """
@@ -136,7 +136,7 @@ lazy_schema = schemathesis.from_pytest_fixture("simple_schema")
 @lazy_schema.parametrize(endpoint="/first")
 def test_a(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/first"
+    assert case.full_path == "/v1/first"
 
 @lazy_schema.parametrize(method="POST")
 def test_b(request, case):
@@ -146,13 +146,13 @@ def test_b(request, case):
 @lazy_schema.parametrize(tag="foo")
 def test_c(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/second"
+    assert case.full_path == "/v1/second"
     assert case.method == "GET"
 
 @lazy_schema.parametrize(operation_id="updateThird")
 def test_d(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/third"
+    assert case.full_path == "/v1/third"
     assert case.method == "PUT"
 """,
         paths={
@@ -201,7 +201,7 @@ def test_a(request, case):
 @lazy_schema.parametrize(endpoint="/second", method=None)
 def test_b(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/second"
+    assert case.full_path == "/v1/second"
 
 @lazy_schema.parametrize()
 def test_c(request, case):
@@ -255,7 +255,7 @@ lazy_schema = schemathesis.from_pytest_fixture("simple_schema", endpoint="/v1/pe
 @lazy_schema.parametrize()
 def test_a(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/pets"
+    assert case.full_path == "/v1/pets"
     assert case.method == "POST"
 """,
         paths={"/pets": {"post": {"responses": {"200": {"description": "OK"}}}}},
@@ -285,7 +285,7 @@ lazy_schema = schemathesis.from_pytest_fixture("simple_schema", endpoint=None, m
 @lazy_schema.parametrize(endpoint="/second", method=None)
 def test_b(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/second"
+    assert case.full_path == "/v1/second"
 """,
         paths={
             "/first": {
@@ -328,7 +328,7 @@ lazy_schema = schemathesis.from_pytest_fixture("simple_schema", endpoint="/v1/fi
 @lazy_schema.parametrize(endpoint="/second", method="GET")
 def test_a(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/second"
+    assert case.full_path == "/v1/second"
     assert case.method == "GET"
 
 @lazy_schema.parametrize(endpoint=None, method="GET")
@@ -339,12 +339,12 @@ def test_b(request, case):
 @lazy_schema.parametrize(endpoint="/second", method=None)
 def test_c(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/second"
+    assert case.full_path == "/v1/second"
 
 @lazy_schema.parametrize()
 def test_d(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/first"
+    assert case.full_path == "/v1/first"
     assert case.method == "POST"
 
 """,

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -28,7 +28,7 @@ def test_uri_loader_custom_kwargs(app, schema_url):
 
 def test_base_url(base_url, schema_url):
     schema = schemathesis.from_uri(schema_url)
-    assert schema.base_url == base_url
+    assert schema.base_url is None
 
 
 @pytest.mark.parametrize("url", ("http://example.com/", "http://example.com"))

--- a/test/test_parametrization.py
+++ b/test/test_parametrization.py
@@ -10,7 +10,7 @@ def test_parametrization(testdir):
 @schema.parametrize()
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method == "GET"
 """
     )
@@ -31,7 +31,7 @@ def test_pytest_parametrize(testdir):
 @schema.parametrize()
 def test_(request, param, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method in ("GET", "POST")
 """,
         paths={
@@ -63,7 +63,7 @@ class TestAPI:
     @schema.parametrize()
     def test_(self, request, case):
         request.config.HYPOTHESIS_CASES += 1
-        assert case.path == "/v1/users"
+        assert case.full_path == "/v1/users"
         assert case.method in ("GET", "POST")
 """,
         paths={
@@ -94,7 +94,7 @@ def test_max_examples(testdir):
 @settings(max_examples=5)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method in ("GET", "POST")
 """,
         paths={"/users": {"get": parameters, "post": parameters}},
@@ -113,7 +113,7 @@ def test_direct_schema(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method == "POST"
     assert_list(case.body)
     assert_str(case.body[0])
@@ -385,7 +385,7 @@ from hypothesis import Phase
 @settings(max_examples=1, phases=[Phase.explicit])
 def test(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.formatted_path == "/v1/users/1/2"
+    assert case.formatted_path == "/users/1/2"
 """,
         schema_name="simple_openapi.yaml",
         paths={
@@ -607,26 +607,6 @@ def test_(request, case):
     result.assert_outcomes(passed=2)
     result.stdout.re_match_lines([r".*\[GET:/api/failure\]", r".*\[GET:/api/success\]"])
     assert len(app["incoming_requests"]) == 2
-
-
-def test_base_url_not_available(testdir):
-    # When the schema is created NOT out of URI
-    testdir.make_test(
-        """
-@schema.parametrize()
-def test_(request, case):
-    with pytest.raises(
-        ValueError,
-        match="^Base URL is required as `base_url` argument in `call` or should be specified "
-              "in the schema constructor as a part of Schema URL.$"
-    ):
-        case._get_base_url(None)
-"""
-    )
-    result = testdir.runpytest("-v")
-    # Then base URL is not detected automatically
-    # And exception will be risen if there is no base URL specified explicitly
-    result.assert_outcomes(passed=1)
 
 
 def test_exceptions_on_collect(testdir):

--- a/test/test_pytest.py
+++ b/test/test_pytest.py
@@ -12,7 +12,7 @@ def param(inner):
 @schema.parametrize()
 def test_(request, param, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.full_path == "/v1/users"
     assert case.method in ("GET", "POST")
 """,
         paths={
@@ -54,7 +54,7 @@ class TestAPI:
     @schema.parametrize()
     def test_(self, request, param, case):
         request.config.HYPOTHESIS_CASES += 1
-        assert case.path == "/v1/users"
+        assert case.full_path == "/v1/users"
         assert case.method in ("GET", "POST")
 """,
         paths={

--- a/test/test_required.py
+++ b/test/test_required.py
@@ -8,7 +8,7 @@ def test_required_parameters(testdir):
 @settings(max_examples=20, suppress_health_check=[HealthCheck.data_too_large])
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "POST"
     assert "id" in case.body
 """,
@@ -40,7 +40,7 @@ def test_not_required_parameters(testdir):
 @settings(max_examples=1)
 def test_(request, case):
     request.config.HYPOTHESIS_CASES += 1
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "GET"
 """,
         **as_param({"in": "query", "name": "key", "required": False, "type": "string"}),
@@ -57,7 +57,7 @@ def test_without_required(testdir):
 @schema.parametrize()
 @settings(max_examples=1)
 def test_(request, case):
-    assert case.path == "/v1/users"
+    assert case.path == "/users"
     assert case.method == "GET"
     if not case.query:
         request.config.HYPOTHESIS_CASES += 1

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -81,7 +81,7 @@ def test_resolving_multiple_files():
         },
     }
     schema = schemathesis.from_dict(raw_schema)
-    assert schema["/api/teapot"]["post"].body == {
+    assert schema["/teapot"]["post"].body == {
         "type": "object",
         "properties": {
             "id": {"type": "integer", "format": "int64"},

--- a/test/test_unittest.py
+++ b/test/test_unittest.py
@@ -19,9 +19,9 @@ from unittest import TestCase
 
 class TestSchema(TestCase):
 
-    @given(case=schema["/v1/users"]["GET"].as_strategy())
+    @given(case=schema["/users"]["GET"].as_strategy())
     def test_something(self, case):
-        assert case.path == "/v1/users"
+        assert case.full_path == "/v1/users"
         assert case.method == "GET"
 """
     )
@@ -37,7 +37,7 @@ from unittest import TestCase
 
 class TestSchema(TestCase):
 
-    @given(case=schema["/v1/users"]["GET"].as_strategy())
+    @given(case=schema["/users"]["GET"].as_strategy())
     def test_something(self, case):
         assert 0
 """

--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -13,7 +13,7 @@ def schema(flask_app):
 
 @pytest.mark.hypothesis_nested
 def test_call(schema, simple_schema):
-    strategy = schema.endpoints["/api/success"]["GET"].as_strategy()
+    strategy = schema.endpoints["/success"]["GET"].as_strategy()
 
     @given(case=strategy)
     def test(case):
@@ -68,7 +68,7 @@ def test_cookies(flask_app):
 @pytest.mark.hypothesis_nested
 @pytest.mark.endpoints("multipart")
 def test_form_data(schema):
-    strategy = schema.endpoints["/api/multipart"]["POST"].as_strategy()
+    strategy = schema.endpoints["/multipart"]["POST"].as_strategy()
 
     @given(case=strategy)
     @settings(max_examples=3, suppress_health_check=[HealthCheck.filter_too_much])
@@ -82,7 +82,7 @@ def test_form_data(schema):
 
 
 def test_not_wsgi(schema):
-    case = Case(schema.endpoints["/api/success"]["GET"])
+    case = Case(schema.endpoints["/success"]["GET"])
     case.endpoint.app = None
     with pytest.raises(
         RuntimeError,


### PR DESCRIPTION
Fixes #511 

TODO:

- [x] Handle base path joining in `get_werkzeug_kwargs`
- [x] Proper changelog entry
- [x] Documentation (+ update relevant)
- [x] Check if `get_base_url` function from `utils` is needed at all
- [x] More docstrings to clarify how `basePath` and `base_url` are handled
- [x] Refactor `Request.from_case` & `Case.get_code_to_reproduce`.
- [x] Make clear what type `base_url` has in what case. There are some hacks that make things work, but I am not 100% sure if they cover all cases

This one definitely goes to 2.0 since it breaks
`base_url` was handled as the `host` part and `basePath` was always joined to it which makes it impossible to set a custom base path at all which is described in #511.

Another use case which it breaks is direct access to endpoints via mapping interface in `BaseSchema`. Now the base path is included:

```
schema["/api/v1/users"]["GET"]
```

After this change:

```
schema["/users"]["GET"]
```

The latter is less error-prone because since the first version will break with overridden base_url, but the schema itself is not changed. This version does not depend on the variable parameter of base_url, which is good.

Refs:
- https://swagger.io/docs/specification/2-0/api-host-and-base-path/
- https://swagger.io/docs/specification/api-host-and-base-path/