### PR TITLE
fix: Passing `workers_num` to `ThreadPoolRunner`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ Added
 - New ``before_add_examples`` hook. `#571`_
 - New ``after_init_cli_run_handlers`` hook. `#575`_
 
+Fixed
+~~~~~
+
+- Passing ``workers_num`` to ``ThreadPoolRunner`` which lead to always using 2 workers in this worker kind. `#579`_
+
 `1.5.1`_ - 2020-05-08
 ---------------------
 
@@ -1040,6 +1045,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#579: https://github.com/kiwicom/schemathesis/issues/579
 .. _#575: https://github.com/kiwicom/schemathesis/issues/575
 .. _#571: https://github.com/kiwicom/schemathesis/issues/571
 .. _#566: https://github.com/kiwicom/schemathesis/issues/566

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -188,6 +188,7 @@ def execute_from_schema(
                     auth_type=auth_type,
                     headers=headers,
                     seed=seed,
+                    workers_num=workers_num,
                     request_timeout=request_timeout,
                     exit_first=exit_first,
                     store_interactions=store_interactions,


### PR DESCRIPTION
Fixes #579 