### PR TITLE
feat: OpenAPI links support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Added
 ~~~~~
 
 - Support for YAML files in references via HTTP & HTTP schemas. `#600`_
+- Stateful testing support via ``Open API links`` syntax. `#548`_
 
 `1.6.3`_ - 2020-05-26
 ---------------------
@@ -1093,6 +1094,7 @@ Fixed
 .. _#566: https://github.com/kiwicom/schemathesis/issues/566
 .. _#562: https://github.com/kiwicom/schemathesis/issues/562
 .. _#559: https://github.com/kiwicom/schemathesis/issues/559
+.. _#548: https://github.com/kiwicom/schemathesis/issues/548
 .. _#546: https://github.com/kiwicom/schemathesis/issues/546
 .. _#542: https://github.com/kiwicom/schemathesis/issues/542
 .. _#540: https://github.com/kiwicom/schemathesis/issues/540

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to schemathesis's documentation!
    usage
    compatibility
    customization
+   stateful
    targeted
    faq
    changelog

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -1,0 +1,102 @@
+.. _stateful:
+
+Stateful testing
+================
+
+By default, Schemathesis generates random data for all endpoints in your schema. With Schemathesis's `stateful testing`
+Schemathesis CLI will try to reuse data from requests that were sent and responses received for generating requests to
+other endpoints.
+
+Open API Links
+--------------
+
+The `official documentation <https://swagger.io/docs/specification/links/>`_ describes this feature like this:
+
+    Using links, you can describe how various values returned by one operation can be used as input for other operations
+
+Schemathesis uses this data to generate additional requests and send them to their respective endpoints.
+It enables Schemathesis to reach much deeper into your codebase, that it is possible with randomly generated data.
+Let's take the example from the docs:
+
+.. code:: yaml
+
+    paths:
+      /users:
+        post:
+          summary: Creates a user and returns the user ID
+          operationId: createUser
+          requestBody:
+            required: true
+            description: User object
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/User'
+          responses:
+            '201':
+              ...
+              links:
+                GetUserByUserId:
+                  operationId: getUser
+                  parameters:
+                    userId: '$response.body#/id'
+      /users/{userId}:
+        get:
+          summary: Gets a user by ID
+          operationId: getUser
+          parameters:
+            - in: path
+              name: userId
+              required: true
+              schema:
+                type: integer
+                format: int64
+
+Based on this definition, Schemathesis will:
+
+- Test ``POST /users`` endpoint as usual;
+- Each response with 201 code will be parsed and used for additional tests of ``GET /users/{user_id}`` endpoint;
+- All data that is not filled from responses will be generated as usual;
+
+In this case, it is much more likely that instead of 404 response for a randomly-generated ``user_id`` we'll receive
+something else - for example, HTTP codes 200 or 500.
+
+By default stateful testing is disabled. You can add it via ``--stateful=links`` CLI option. Please, note, that more
+different algorithms for stateful testing might be implemented in the future.
+
+.. code:: bash
+
+    schemathesis run --stateful=links http://0.0.0.0/swagger.yaml
+
+    ...
+
+    POST /api/users/ .                                     [ 33%]
+        -> GET /api/users/{user_id} .                      [ 50%]
+            -> PATCH /api/users/{user_id} .                [ 60%]
+        -> PATCH /api/users/{user_id} .                    [ 66%]
+    GET /api/users/{user_id} .                             [ 83%]
+        -> PATCH /api/users/{user_id} .                    [ 85%]
+    PATCH /api/users/{user_id} .                           [100%]
+
+    ...
+
+Each additional test will be indented and prefixed with ``->`` in the CLI output.
+You can specify recursive links if you want, the default recursion depth limit is ``5``, it can be changed with
+``--stateful-recursion-limit=<N>`` CLI option.
+
+Even though this feature appears only in Open API 3.0 specification, under Open API 2.0 you can use it
+via the ``x-links`` extension, the syntax is the same, but you need to use the ``x-links`` keyword instead of ``links``.
+
+The `runtime expressions <https://swagger.io/docs/specification/links/#runtime-expressions>`_ are supported with the
+following restriction:
+
+- Symbol ``}`` can not be used as a part of a JSON pointer even though it is a valid symbol.
+  This is done due to ambiguity in the runtime expressions syntax, where ``}`` cannot be distinguished from the
+  closing bracket of an embedded runtime expression.
+
+**IMPORTANT**. The Open API standard defines ``requestBody`` keyword value in this way:
+
+    A literal value or {expression} to use as a request body when calling the target operation.
+
+This means you cannot use multiple runtime expressions for different parameters you always have to provide either a literal
+or an expression.

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -13,7 +13,7 @@ from .. import checks as checks_module
 from .. import models, runner
 from ..fixups import ALL_FIXUPS
 from ..hooks import GLOBAL_HOOK_DISPATCHER, HookContext, HookDispatcher, HookScope
-from ..runner import events
+from ..runner import DEFAULT_STATEFUL_RECURSION_LIMIT, events
 from ..runner.targeted import DEFAULT_TARGETS_NAMES, Target
 from ..types import Filter
 from ..utils import WSGIResponse
@@ -171,6 +171,15 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
     type=click.Choice(list(ALL_FIXUPS) + ["all"]),
 )
 @click.option(
+    "--stateful", help="Utilize stateful testing capabilities.", type=click.Choice(["links"]),
+)
+@click.option(
+    "--stateful-recursion-limit",
+    help="Limit recursion depth for stateful testing.",
+    default=DEFAULT_STATEFUL_RECURSION_LIMIT,
+    type=click.IntRange(1, 100),
+)
+@click.option(
     "--hypothesis-deadline",
     help="Duration in milliseconds that each individual example with a test is not allowed to exceed.",
     # max value to avoid overflow. It is maximum amount of days in milliseconds
@@ -219,6 +228,8 @@ def run(  # pylint: disable=too-many-arguments
     show_errors_tracebacks: bool = False,
     store_network_log: Optional[click.utils.LazyFile] = None,
     fixups: Tuple[str] = (),  # type: ignore
+    stateful: Optional[str] = None,
+    stateful_recursion_limit: int = DEFAULT_STATEFUL_RECURSION_LIMIT,
     hypothesis_deadline: Optional[Union[int, NotSet]] = None,
     hypothesis_derandomize: Optional[bool] = None,
     hypothesis_max_examples: Optional[int] = None,
@@ -260,6 +271,8 @@ def run(  # pylint: disable=too-many-arguments
         workers_num=workers_num,
         validate_schema=validate_schema,
         fixups=fixups,
+        stateful=stateful,
+        stateful_recursion_limit=stateful_recursion_limit,
         hypothesis_deadline=hypothesis_deadline,
         hypothesis_derandomize=hypothesis_derandomize,
         hypothesis_max_examples=hypothesis_max_examples,

--- a/src/schemathesis/cli/output/default.py
+++ b/src/schemathesis/cli/output/default.py
@@ -306,6 +306,10 @@ def handle_initialized(context: ExecutionContext, event: events.Initialized) -> 
 def handle_before_execution(context: ExecutionContext, event: events.BeforeExecution) -> None:
     """Display what method / endpoint will be tested next."""
     message = f"{event.method} {event.path} "
+    if event.recursion_level > 0:
+        message = f"{'    ' * event.recursion_level}-> {message}"
+        # This value is not `None` - the value is set in runtime before this line
+        context.endpoints_count += 1  # type: ignore
     context.current_line_length = len(message)
     click.echo(message, nl=False)
 

--- a/src/schemathesis/cli/output/short.py
+++ b/src/schemathesis/cli/output/short.py
@@ -6,13 +6,16 @@ from ..handlers import EventHandler
 from . import default
 
 
+def handle_before_execution(context: ExecutionContext, event: events.BeforeExecution) -> None:
+    if event.recursion_level > 0:
+        context.endpoints_count += 1  # type: ignore
+
+
 def handle_after_execution(context: ExecutionContext, event: events.AfterExecution) -> None:
     context.endpoints_processed += 1
     context.results.append(event.result)
     context.hypothesis_output.extend(event.hypothesis_output)
     default.display_execution_result(context, event)
-    if context.endpoints_processed == context.endpoints_count:
-        click.echo()
 
 
 class ShortOutputStyleHandler(EventHandler):
@@ -23,9 +26,13 @@ class ShortOutputStyleHandler(EventHandler):
         """
         if isinstance(event, events.Initialized):
             default.handle_initialized(context, event)
+        if isinstance(event, events.BeforeExecution):
+            handle_before_execution(context, event)
         if isinstance(event, events.AfterExecution):
             handle_after_execution(context, event)
         if isinstance(event, events.Finished):
+            if context.endpoints_count == context.endpoints_processed:
+                click.echo()
             default.handle_finished(context, event)
         if isinstance(event, events.Interrupted):
             default.handle_interrupted(context, event)

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -11,7 +11,14 @@ from ..schemas import BaseSchema
 from ..types import Filter, NotSet, RawAuth
 from ..utils import dict_not_none_values, dict_true_values, file_exists, get_base_url, get_requests_auth, import_app
 from . import events
-from .impl import BaseRunner, SingleThreadRunner, SingleThreadWSGIRunner, ThreadPoolRunner, ThreadPoolWSGIRunner
+from .impl import (
+    DEFAULT_STATEFUL_RECURSION_LIMIT,
+    BaseRunner,
+    SingleThreadRunner,
+    SingleThreadWSGIRunner,
+    ThreadPoolRunner,
+    ThreadPoolWSGIRunner,
+)
 from .targeted import DEFAULT_TARGETS, Target
 
 
@@ -26,6 +33,8 @@ def prepare(  # pylint: disable=too-many-arguments
     exit_first: bool = False,
     store_interactions: bool = False,
     fixups: Iterable[str] = (),
+    stateful: Optional[str] = None,
+    stateful_recursion_limit: int = DEFAULT_STATEFUL_RECURSION_LIMIT,
     # Schema loading
     loader: Callable = loaders.from_uri,
     base_url: Optional[str] = None,
@@ -87,6 +96,8 @@ def prepare(  # pylint: disable=too-many-arguments
         request_timeout=request_timeout,
         store_interactions=store_interactions,
         fixups=fixups,
+        stateful=stateful,
+        stateful_recursion_limit=stateful_recursion_limit,
     )
 
 
@@ -132,6 +143,8 @@ def execute_from_schema(
     exit_first: bool = False,
     store_interactions: bool = False,
     fixups: Iterable[str] = (),
+    stateful: Optional[str] = None,
+    stateful_recursion_limit: int = DEFAULT_STATEFUL_RECURSION_LIMIT,
 ) -> Generator[events.ExecutionEvent, None, None]:
     """Execute tests for the given schema.
 
@@ -177,6 +190,8 @@ def execute_from_schema(
                     workers_num=workers_num,
                     exit_first=exit_first,
                     store_interactions=store_interactions,
+                    stateful=stateful,
+                    stateful_recursion_limit=stateful_recursion_limit,
                 )
             else:
                 runner = ThreadPoolRunner(
@@ -192,6 +207,8 @@ def execute_from_schema(
                     request_timeout=request_timeout,
                     exit_first=exit_first,
                     store_interactions=store_interactions,
+                    stateful=stateful,
+                    stateful_recursion_limit=stateful_recursion_limit,
                 )
         else:
             if schema.app:
@@ -206,6 +223,8 @@ def execute_from_schema(
                     seed=seed,
                     exit_first=exit_first,
                     store_interactions=store_interactions,
+                    stateful=stateful,
+                    stateful_recursion_limit=stateful_recursion_limit,
                 )
             else:
                 runner = SingleThreadRunner(
@@ -220,6 +239,8 @@ def execute_from_schema(
                     request_timeout=request_timeout,
                     exit_first=exit_first,
                     store_interactions=store_interactions,
+                    stateful=stateful,
+                    stateful_recursion_limit=stateful_recursion_limit,
                 )
         yield from runner.execute()
     except Exception as exc:

--- a/src/schemathesis/runner/events.py
+++ b/src/schemathesis/runner/events.py
@@ -49,10 +49,11 @@ class BeforeExecution(ExecutionEvent):
 
     method: str = attr.ib()  # pragma: no mutate
     path: str = attr.ib()  # pragma: no mutate
+    recursion_level: int = attr.ib()  # pragma: no mutate
 
     @classmethod
-    def from_endpoint(cls, endpoint: Endpoint) -> "BeforeExecution":
-        return cls(method=endpoint.method, path=endpoint.path)
+    def from_endpoint(cls, endpoint: Endpoint, recursion_level: int) -> "BeforeExecution":
+        return cls(method=endpoint.method, path=endpoint.path, recursion_level=recursion_level)
 
 
 @attr.s(slots=True)  # pragma: no mutate

--- a/src/schemathesis/runner/impl/__init__.py
+++ b/src/schemathesis/runner/impl/__init__.py
@@ -1,3 +1,3 @@
-from .core import BaseRunner
+from .core import DEFAULT_STATEFUL_RECURSION_LIMIT, BaseRunner
 from .solo import SingleThreadRunner, SingleThreadWSGIRunner
 from .threadpool import ThreadPoolRunner, ThreadPoolWSGIRunner

--- a/src/schemathesis/runner/impl/solo.py
+++ b/src/schemathesis/runner/impl/solo.py
@@ -6,7 +6,7 @@ import attr
 from ...models import TestResultSet
 from ...utils import get_requests_auth
 from .. import events
-from .core import BaseRunner, get_session, network_test, run_test, wsgi_test
+from .core import BaseRunner, get_session, network_test, wsgi_test
 
 
 @attr.s(slots=True)  # pragma: no mutate
@@ -16,38 +16,34 @@ class SingleThreadRunner(BaseRunner):
     def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
         auth = get_requests_auth(self.auth, self.auth_type)
         with get_session(auth) as session:
-            for endpoint, test in self.schema.get_all_tests(network_test, self.hypothesis_settings, self.seed):
-                for event in run_test(
-                    endpoint,
-                    test,
-                    self.checks,
-                    self.targets,
-                    results,
-                    session=session,
-                    headers=self.headers,
-                    request_timeout=self.request_timeout,
-                    store_interactions=self.store_interactions,
-                ):
-                    yield event
-                    if isinstance(event, events.Interrupted):
-                        return
+            yield from self._run_tests(
+                self.schema.get_all_tests,
+                network_test,
+                self.hypothesis_settings,
+                self.seed,
+                checks=self.checks,
+                targets=self.targets,
+                results=results,
+                session=session,
+                headers=self.headers,
+                request_timeout=self.request_timeout,
+                store_interactions=self.store_interactions,
+            )
 
 
 @attr.s(slots=True)  # pragma: no mutate
 class SingleThreadWSGIRunner(SingleThreadRunner):
     def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
-        for endpoint, test in self.schema.get_all_tests(wsgi_test, self.hypothesis_settings, self.seed):
-            for event in run_test(
-                endpoint,
-                test,
-                self.checks,
-                self.targets,
-                results,
-                auth=self.auth,
-                auth_type=self.auth_type,
-                headers=self.headers,
-                store_interactions=self.store_interactions,
-            ):
-                yield event
-                if isinstance(event, events.Interrupted):
-                    return
+        yield from self._run_tests(
+            self.schema.get_all_tests,
+            wsgi_test,
+            self.hypothesis_settings,
+            self.seed,
+            checks=self.checks,
+            targets=self.targets,
+            results=results,
+            auth=self.auth,
+            auth_type=self.auth_type,
+            headers=self.headers,
+            store_interactions=self.store_interactions,
+        )

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -8,7 +8,7 @@ Their responsibilities:
 They give only static definitions of endpoints.
 """
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, Generator, Iterator, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Generator, Iterator, Optional, Sequence, Tuple, Union
 
 import attr
 import hypothesis
@@ -18,8 +18,9 @@ from ._hypothesis import make_test_or_exception
 from .exceptions import InvalidSchema
 from .hooks import HookContext, HookDispatcher, HookLocation, HookScope, dispatch, warn_deprecated_hook
 from .models import Endpoint
+from .stateful import StatefulTest
 from .types import Filter, GenericTest, Hook, NotSet
-from .utils import NOT_SET, deprecated
+from .utils import NOT_SET, GenericResponse, deprecated
 
 
 @attr.s()  # pragma: no mutate
@@ -58,6 +59,12 @@ class BaseSchema(Mapping):
         return len(list(self.get_all_endpoints()))
 
     def get_all_endpoints(self) -> Generator[Endpoint, None, None]:
+        raise NotImplementedError
+
+    def get_stateful_tests(
+        self, response: GenericResponse, endpoint: Endpoint, stateful: Optional[str]
+    ) -> Sequence[StatefulTest]:
+        """Get a list of additional tests, that should be executed after this response from the endpoint."""
         raise NotImplementedError
 
     def get_all_tests(

--- a/src/schemathesis/specs/openapi/expressions/__init__.py
+++ b/src/schemathesis/specs/openapi/expressions/__init__.py
@@ -1,0 +1,20 @@
+"""Runtime expressions support.
+
+https://swagger.io/docs/specification/links/#runtime-expressions
+"""
+from typing import Any
+
+from . import lexer, nodes, parser
+from .context import ExpressionContext
+
+
+def evaluate(expr: Any, context: ExpressionContext) -> str:
+    """Evaluate runtime expression in context."""
+    if not isinstance(expr, str):
+        # Can be a non-string constant
+        return expr
+    parts = [node.evaluate(context) for node in parser.parse(expr)]
+    if len(parts) == 1:
+        return parts[0]  # keep the return type the same as the internal value type
+    # otherwise concatenate into a string
+    return "".join(map(str, parts))

--- a/src/schemathesis/specs/openapi/expressions/context.py
+++ b/src/schemathesis/specs/openapi/expressions/context.py
@@ -1,0 +1,12 @@
+import attr
+
+from ....models import Case
+from ....utils import GenericResponse
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class ExpressionContext:
+    """Context in what an expression are evaluated."""
+
+    response: GenericResponse = attr.ib()  # pragma: no mutate
+    case: Case = attr.ib()  # pragma: no mutate

--- a/src/schemathesis/specs/openapi/expressions/errors.py
+++ b/src/schemathesis/specs/openapi/expressions/errors.py
@@ -1,0 +1,6 @@
+class RuntimeExpressionError(ValueError):
+    """Generic error that happened during evaluation of a runtime expression."""
+
+
+class UnknownToken(RuntimeExpressionError):
+    """Don't know how to handle a token value."""

--- a/src/schemathesis/specs/openapi/expressions/lexer.py
+++ b/src/schemathesis/specs/openapi/expressions/lexer.py
@@ -1,0 +1,133 @@
+"""Lexical analysis of runtime expressions."""
+from enum import Enum, unique
+from typing import Callable, Generator
+
+import attr
+
+
+@unique  # pragma: no mutate
+class TokenType(Enum):
+    VARIABLE = 1  # pragma: no mutate
+    STRING = 2  # pragma: no mutate
+    POINTER = 3  # pragma: no mutate
+    DOT = 4  # pragma: no mutate
+    LBRACKET = 5  # pragma: no mutate
+    RBRACKET = 6  # pragma: no mutate
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class Token:
+    """Lexical token that may occur in a runtime expression."""
+
+    value: str = attr.ib()  # pragma: no mutate
+    type_: TokenType = attr.ib()  # pragma: no mutate
+
+    # Helpers for cleaner instantiation
+
+    @classmethod
+    def variable(cls, value: str) -> "Token":
+        return cls(value, TokenType.VARIABLE)
+
+    @classmethod
+    def string(cls, value: str) -> "Token":
+        return cls(value, TokenType.STRING)
+
+    @classmethod
+    def pointer(cls, value: str) -> "Token":
+        return cls(value, TokenType.POINTER)
+
+    @classmethod
+    def lbracket(cls) -> "Token":
+        return cls("{", TokenType.LBRACKET)
+
+    @classmethod
+    def rbracket(cls) -> "Token":
+        return cls("}", TokenType.RBRACKET)
+
+    @classmethod
+    def dot(cls) -> "Token":
+        return cls(".", TokenType.DOT)
+
+    # Helpers for simpler type comparison
+
+    @property
+    def is_string(self) -> bool:
+        return self.type_ == TokenType.STRING
+
+    @property
+    def is_variable(self) -> bool:
+        return self.type_ == TokenType.VARIABLE
+
+    @property
+    def is_dot(self) -> bool:
+        return self.type_ == TokenType.DOT
+
+    @property
+    def is_pointer(self) -> bool:
+        return self.type_ == TokenType.POINTER
+
+    @property
+    def is_left_bracket(self) -> bool:
+        return self.type_ == TokenType.LBRACKET
+
+    @property
+    def is_right_bracket(self) -> bool:
+        return self.type_ == TokenType.RBRACKET
+
+
+TokenGenerator = Generator[Token, None, None]
+
+
+def tokenize(expression: str) -> TokenGenerator:
+    """Do lexical analysis of the expression and return a list of tokens."""
+    cursor = 0
+
+    def is_eol() -> bool:
+        return cursor == len(expression)
+
+    def current_symbol() -> str:
+        return expression[cursor]
+
+    def move() -> None:
+        nonlocal cursor
+        cursor += 1
+
+    def move_until(predicate: Callable[[], bool]) -> None:
+        move()
+        while not predicate():
+            move()
+
+    stop_symbols = {"$", ".", "{", "}", "#"}
+
+    while not is_eol():
+        if current_symbol() == "$":
+            start = cursor
+            move_until(lambda: is_eol() or current_symbol() in stop_symbols)
+            yield Token.variable(expression[start:cursor])
+        elif current_symbol() == ".":
+            yield Token.dot()
+            move()
+        elif current_symbol() == "{":
+            yield Token.lbracket()
+            move()
+        elif current_symbol() == "}":
+            yield Token.rbracket()
+            move()
+        elif current_symbol() == "#":
+            start = cursor
+            # Symbol '}' is valid inside a JSON pointer, but also denotes closing of an embedded runtime expression
+            # This is an ambiguous situation, for example:
+            # Expression: `ID_{$request.body#/foo}}`
+            # Body: `{"foo}": 1, "foo": 2}`
+            # It could be evaluated differently:
+            #   - `ID_1` if we take the last bracket as the closing one
+            #   - `ID_2}` if we take the first bracket as the closing one
+            # In this situation we take the second approach, to support cases like this:
+            # `ID_{$response.body#/foo}_{$response.body#/bar}`
+            # Which is much easier if we treat `}` as a closing bracket of an embedded runtime expression
+            move_until(lambda: is_eol() or current_symbol() == "}")
+            yield Token.pointer(expression[start:cursor])
+        else:
+            start = cursor
+            move_until(lambda: is_eol() or current_symbol() in stop_symbols)
+            yield Token.string(expression[start:cursor])

--- a/src/schemathesis/specs/openapi/expressions/nodes.py
+++ b/src/schemathesis/specs/openapi/expressions/nodes.py
@@ -1,0 +1,126 @@
+"""Expression nodes description and evaluation logic."""
+import json
+from enum import Enum, unique
+from typing import Any, Optional
+
+import attr
+
+from ....utils import WSGIResponse
+from . import pointers
+from .context import ExpressionContext
+from .errors import RuntimeExpressionError
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class Node:
+    """Generic expression node."""
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        raise NotImplementedError
+
+
+@unique
+class NodeType(Enum):
+    URL = "$url"
+    METHOD = "$method"
+    STATUS_CODE = "$statusCode"
+    REQUEST = "$request"
+    RESPONSE = "$response"
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class String(Node):
+    """A simple string that is not evaluated somehow specifically."""
+
+    value: str = attr.ib()  # pragma: no mutate
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        """String tokens are passed as they are.
+
+        ``foo{$request.path.id}``
+
+        "foo" is String token there.
+        """
+        return self.value
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class URL(Node):
+    """A node for `$url` expression."""
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        return context.case.get_full_url()
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class Method(Node):
+    """A node for `$method` expression."""
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        return context.case.endpoint.method
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class StatusCode(Node):
+    """A node for `$statusCode` expression."""
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        return str(context.response.status_code)
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class NonBodyRequest(Node):
+    """A node for `$request` expressions where location is not `body`."""
+
+    location: str = attr.ib()  # pragma: no mutate
+    parameter: str = attr.ib()  # pragma: no mutate
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        container = {
+            "query": context.case.query,
+            "path": context.case.path_parameters,
+            "header": context.case.headers,  # should be case-insensitive
+        }[self.location] or {}
+        return str(container[self.parameter])
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class BodyRequest(Node):
+    """A node for `$request` expressions where location is `body`."""
+
+    pointer: Optional[str] = attr.ib(default=None)  # pragma: no mutate
+
+    def evaluate(self, context: ExpressionContext) -> Any:
+        if self.pointer is None:
+            try:
+                return json.dumps(context.case.body)
+            except TypeError as exc:
+                raise RuntimeExpressionError("The request body is not JSON-serializable") from exc
+        document = context.case.body
+        return pointers.resolve(document, self.pointer[1:])
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class HeaderResponse(Node):
+    """A node for `$response.header` expressions."""
+
+    parameter: str = attr.ib()  # pragma: no mutate
+
+    def evaluate(self, context: ExpressionContext) -> str:
+        return context.response.headers[self.parameter]
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class BodyResponse(Node):
+    """A node for `$response.body` expressions."""
+
+    pointer: Optional[str] = attr.ib(default=None)  # pragma: no mutate
+
+    def evaluate(self, context: ExpressionContext) -> Any:
+        if self.pointer is None:
+            return context.response.text
+        if isinstance(context.response, WSGIResponse):
+            document = context.response.json
+        else:
+            document = context.response.json()
+        return pointers.resolve(document, self.pointer[1:])

--- a/src/schemathesis/specs/openapi/expressions/parser.py
+++ b/src/schemathesis/specs/openapi/expressions/parser.py
@@ -1,0 +1,93 @@
+from functools import lru_cache
+from typing import Generator, List, Union
+
+from . import lexer, nodes
+from .errors import RuntimeExpressionError, UnknownToken
+
+
+@lru_cache()  # pragma: no mutate
+def parse(expr: str) -> List[nodes.Node]:
+    """Parse lexical tokens into concrete expression nodes."""
+    return list(_parse(expr))
+
+
+def _parse(expr: str) -> Generator[nodes.Node, None, None]:
+    tokens = lexer.tokenize(expr)
+    brackets_stack: List[str] = []
+    for token in tokens:
+        if token.is_string:
+            yield nodes.String(token.value)
+        elif token.is_variable:
+            yield from _parse_variable(tokens, token, expr)
+        elif token.is_left_bracket:
+            if brackets_stack:
+                raise RuntimeExpressionError("Nested embedded expressions are not allowed")
+            brackets_stack.append("{")
+        elif token.is_right_bracket:
+            if not brackets_stack:
+                raise RuntimeExpressionError("Unmatched bracket")
+            brackets_stack.pop()
+    if brackets_stack:
+        raise RuntimeExpressionError("Unmatched bracket")
+
+
+def _parse_variable(tokens: lexer.TokenGenerator, token: lexer.Token, expr: str) -> Generator[nodes.Node, None, None]:
+    if token.value == nodes.NodeType.URL.value:
+        yield nodes.URL()
+    elif token.value == nodes.NodeType.METHOD.value:
+        yield nodes.Method()
+    elif token.value == nodes.NodeType.STATUS_CODE.value:
+        yield nodes.StatusCode()
+    elif token.value == nodes.NodeType.REQUEST.value:
+        yield _parse_request(tokens, expr)
+    elif token.value == nodes.NodeType.RESPONSE.value:
+        yield _parse_response(tokens, expr)
+    else:
+        raise UnknownToken(token.value)
+
+
+def _parse_request(tokens: lexer.TokenGenerator, expr: str) -> Union[nodes.BodyRequest, nodes.NonBodyRequest]:
+    skip_dot(tokens, "$request")
+    location = next(tokens)
+    if location.value in ("query", "path", "header"):
+        skip_dot(tokens, f"$request.{location.value}")
+        parameter = take_string(tokens, expr)
+        return nodes.NonBodyRequest(location.value, parameter)
+    if location.value == "body":
+        try:
+            token = next(tokens)
+            if token.is_pointer:
+                return nodes.BodyRequest(token.value)
+        except StopIteration:
+            return nodes.BodyRequest()
+    raise RuntimeExpressionError(f"Invalid expression: {expr}")
+
+
+def _parse_response(tokens: lexer.TokenGenerator, expr: str) -> Union[nodes.HeaderResponse, nodes.BodyResponse]:
+    skip_dot(tokens, "$response")
+    location = next(tokens)
+    if location.value == "header":
+        skip_dot(tokens, f"$response.{location.value}")
+        parameter = take_string(tokens, expr)
+        return nodes.HeaderResponse(parameter)
+    if location.value == "body":
+        try:
+            token = next(tokens)
+            if token.is_pointer:
+                return nodes.BodyResponse(token.value)
+        except StopIteration:
+            return nodes.BodyResponse()
+    raise RuntimeExpressionError(f"Invalid expression: {expr}")
+
+
+def skip_dot(tokens: lexer.TokenGenerator, name: str) -> None:
+    token = next(tokens)
+    if not token.is_dot:
+        raise RuntimeExpressionError(f"`{name}` expression should be followed by a dot (`.`). Got: {token.value}")
+
+
+def take_string(tokens: lexer.TokenGenerator, expr: str) -> str:
+    parameter = next(tokens)
+    if not parameter.is_string:
+        raise RuntimeExpressionError(f"Invalid expression: {expr}")
+    return parameter.value

--- a/src/schemathesis/specs/openapi/expressions/pointers.py
+++ b/src/schemathesis/specs/openapi/expressions/pointers.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, List, Optional, Union
+
+
+def resolve(document: Any, pointer: str) -> Optional[Union[Dict, List, str, int, float]]:
+    """Implementation is adapted from Rust's `serde-json` crate.
+
+    Ref: https://github.com/serde-rs/json/blob/master/src/value/mod.rs#L751
+    """
+    if not pointer:
+        return document
+    if not pointer.startswith("/"):
+        return None
+
+    def replace(value: str) -> str:
+        return value.replace("~1", "/").replace("~0", "~")
+
+    tokens = map(replace, pointer.split("/")[1:])
+    target = document
+    for token in tokens:
+        if isinstance(target, dict):
+            target = target.get(token)
+        elif isinstance(target, list):
+            try:
+                target = target[int(token)]
+            except IndexError:
+                return None
+        else:
+            return None
+    return target

--- a/src/schemathesis/specs/openapi/links.py
+++ b/src/schemathesis/specs/openapi/links.py
@@ -1,0 +1,181 @@
+"""Open API links support.
+
+Based on https://swagger.io/docs/specification/links/
+"""
+from copy import deepcopy
+from typing import Any, Dict, List, NoReturn, Optional, Sequence, Tuple
+
+import attr
+
+from ...models import Case, Endpoint
+from ...stateful import ParsedData, StatefulTest
+from ...utils import NOT_SET, GenericResponse
+from . import expressions
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class Link(StatefulTest):
+    endpoint: Endpoint = attr.ib()  # pragma: no mutate
+    parameters: Dict[str, Any] = attr.ib()  # pragma: no mutate
+    request_body: Any = attr.ib(default=NOT_SET)  # pragma: no mutate
+
+    @classmethod
+    def from_definition(cls, name: str, definition: Dict[str, Dict[str, Any]], source_endpoint: Endpoint) -> "Link":
+        # Links can be behind a reference
+        _, definition = source_endpoint.schema.resolver.resolve_in_scope(  # type: ignore
+            definition, source_endpoint.definition.scope
+        )
+        if "operationId" in definition:
+            # source_endpoint.schema is `BaseOpenAPISchema` and has this method
+            endpoint = source_endpoint.schema.get_endpoint_by_operation_id(definition["operationId"])  # type: ignore
+        else:
+            endpoint = source_endpoint.schema.get_endpoint_by_reference(definition["operationRef"])  # type: ignore
+        return cls(
+            # Pylint can't detect that endpoint is always defined at this point
+            # E.g. if there is no matching endpoint or no endpoints at all, then a ValueError will be risen
+            name=name,
+            endpoint=endpoint,  # pylint: disable=undefined-loop-variable
+            parameters=definition.get("parameters", {}),
+            request_body=definition.get("requestBody", NOT_SET),  # `None` might be a valid value - `null`
+        )
+
+    def parse(self, case: Case, response: GenericResponse) -> ParsedData:
+        """Parse data into a structure expected by links definition."""
+        context = expressions.ExpressionContext(case=case, response=response)
+        parameters = {
+            parameter: expressions.evaluate(expression, context) for parameter, expression in self.parameters.items()
+        }
+        return ParsedData(
+            parameters=parameters,
+            # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#link-object
+            # > A literal value or {expression} to use as a request body when calling the target operation.
+            # In this case all literals will be passed as is, and expressions will be evaluated
+            body=expressions.evaluate(self.request_body, context),
+        )
+
+    def make_endpoint(self, data: List[ParsedData]) -> Endpoint:
+        """Create a modified version of the original endpoint with additional data merged in."""
+        # For each response from the previous endpoint run we create a new JSON schema and collect all results
+        # Instead of unconditionally creating `oneOf` list we gather it separately to optimize
+        # the resulting schema later
+        variants: Dict[str, List[Dict[str, Any]]] = {
+            "path_parameters": [],
+            "query": [],
+            "headers": [],
+            "cookies": [],
+            "body": [],
+        }
+
+        def make_variants(_item: ParsedData, _templates: Dict[str, Optional[Dict[str, Any]]]) -> None:
+            """Add each item from the previous test run to the proper place in the schema.
+
+            Example:
+                 If there is `user_id` parameter defined in the query, and we have `{"user_id": 1}` as data, then
+                 `1` will be added as a constant in a schema that is responsible for query generation
+
+            """
+            for name, value in _item.parameters.items():
+                name, container = self._get_container_by_parameter_name(name, _templates)
+                container["properties"][name]["const"] = value
+            if _item.body is not NOT_SET:
+                variants["body"].append({"const": _item.body})
+
+        def add_variants(_templates: Dict[str, Optional[Dict[str, Any]]]) -> None:
+            """Add all created schemas as variants to their locations."""
+            for location, container_name in LOCATION_TO_CONTAINER.items():
+                variant = _templates[location]
+                # There could be no schema defined for e.g. `query`, then the container in the `Endpoint` instance
+                # is `None`. The resulting
+                if variant is not None:
+                    variants[container_name].append(variant)
+
+        # It is possible that on the previous test level we gathered non-unique data samples, we can remove duplicates
+        # It might happen because of how shrinking works, some examples are retried
+        for item in set(data):
+            # Copies of the original schemas are templates that could be extended from the data gathered in the
+            # previous endpoint test
+            templates: Dict[str, Optional[Dict[str, Any]]] = {
+                location: deepcopy(getattr(self.endpoint, container_name))
+                for location, container_name in LOCATION_TO_CONTAINER.items()
+            }
+            make_variants(item, templates)
+            add_variants(templates)
+        components = self._convert_to_schema(variants)
+        return self.endpoint.__class__(
+            path=self.endpoint.path,
+            method=self.endpoint.method,
+            definition=self.endpoint.definition,
+            schema=self.endpoint.schema,
+            app=self.endpoint.app,
+            base_url=self.endpoint.base_url,
+            path_parameters=components["path_parameters"],
+            query=components["query"],
+            headers=components["headers"],
+            cookies=components["cookies"],
+            body=components["body"],
+            form_data=self.endpoint.form_data,
+        )
+
+    def _get_container_by_parameter_name(
+        self, full_name: str, templates: Dict[str, Optional[Dict[str, Any]]]
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Detect in what request part the parameters is defined."""
+        location: Optional[str]
+        try:
+            # The parameter name is prefixed with its location. Example: `path.id`
+            location, name = full_name.split(".")
+        except ValueError:
+            location, name = None, full_name
+        if location:
+            try:
+                schema = templates[location]
+            except KeyError:
+                self._unknown_parameter(full_name)
+        else:
+            for schema in templates.values():
+                if schema is not None and name in schema["properties"]:
+                    break
+            else:
+                self._unknown_parameter(full_name)
+        if schema is None:
+            self._unknown_parameter(full_name)
+        return name, schema
+
+    def _convert_to_schema(self, variants: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+        """Convert gathered schema variants to a JSON schema.
+
+        No variants gathered - the original schema is used
+        One variant - it is used directly
+        Many variants - they are combined via `anyOf`
+        """
+
+        def convert(name: str, component: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+            if len(component) == 0:
+                return getattr(self.endpoint, name)
+            if len(component) == 1:
+                return component[0]
+            return {"anyOf": component}
+
+        return {name: convert(name, component) for name, component in variants.items()}
+
+    def _unknown_parameter(self, name: str) -> NoReturn:
+        raise ValueError(f"Parameter `{name}` is not defined in endpoint {self.endpoint.method} {self.endpoint.path}")
+
+
+LOCATION_TO_CONTAINER = {
+    "path": "path_parameters",
+    "query": "query",
+    "header": "headers",
+    "cookie": "cookies",
+}
+
+
+def get_links(response: GenericResponse, endpoint: Endpoint, field: str) -> Sequence[Link]:
+    """Get `x-links` / `links` definitions from the schema."""
+    responses = endpoint.definition.raw["responses"]
+    if str(response.status_code) in responses:
+        response_definition = responses[str(response.status_code)]
+    else:
+        response_definition = responses.get("default", {})
+    links = response_definition.get(field, {})
+    return [Link.from_definition(name, definition, endpoint) for name, definition in links.items()]

--- a/src/schemathesis/stateful.py
+++ b/src/schemathesis/stateful.py
@@ -1,0 +1,43 @@
+import json
+from typing import Any, Dict, List
+
+import attr
+
+from .models import Case, Endpoint
+from .utils import NOT_SET, GenericResponse
+
+
+@attr.s(slots=True, hash=False)  # pragma: no mutate
+class ParsedData:
+    """A structure that holds information parsed from a test outcomes.
+
+    It is used later to create a new version of an endpoint that will reuse this data.
+    """
+
+    parameters: Dict[str, Any] = attr.ib()  # pragma: no mutate
+    body: Any = attr.ib(default=NOT_SET)  # pragma: no mutate
+
+    def __hash__(self) -> int:
+        """Custom hash simplifies deduplication of parsed data."""
+        value = hash(tuple(self.parameters.items()))  # parameters never contain nested dicts / lists
+        if self.body is not NOT_SET:
+            if isinstance(self.body, (dict, list)):
+                # The simplest way to get a hash of a potentially nested structure
+                value ^= hash(json.dumps(self.body))
+            else:
+                # These types should be hashable
+                value ^= hash(self.body)
+        return value
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class StatefulTest:
+    """A template for a test that will be executed after another one by reusing the outcomes from it."""
+
+    name: str = attr.ib()  # pragma: no mutate
+
+    def parse(self, case: Case, response: GenericResponse) -> ParsedData:
+        raise NotImplementedError
+
+    def make_endpoint(self, data: List[ParsedData]) -> Endpoint:
+        raise NotImplementedError

--- a/test/apps/_aiohttp/__init__.py
+++ b/test/apps/_aiohttp/__init__.py
@@ -53,6 +53,7 @@ def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> web.Appli
         [web.get("/swagger.yaml", schema), web.get("/cookies", set_cookies)]
         + [web.route(item.value[0], item.value[1], wrapper(item.name)) for item in Endpoint]
     )
+    app["users"] = {}
     app["incoming_requests"] = incoming_requests
     app["schema_requests"] = schema_requests
     app["config"] = {"should_fail": True, "schema_data": make_schema(endpoints)}
@@ -61,6 +62,7 @@ def create_app(endpoints: Tuple[str, ...] = ("success", "failure")) -> web.Appli
 
 def reset_app(app: web.Application, endpoints: Tuple[str, ...] = ("success", "failure")) -> None:
     """Clean up all internal containers of the application and resets its config."""
+    app["users"].clear()
     app["incoming_requests"][:] = []
     app["schema_requests"][:] = []
     app["config"].update({"should_fail": True, "schema_data": make_schema(endpoints)})

--- a/test/apps/_aiohttp/handlers.py
+++ b/test/apps/_aiohttp/handlers.py
@@ -109,6 +109,33 @@ async def upload_file(request: web.Request) -> web.Response:
     return web.json_response({"size": request.content_length})
 
 
+async def create_user(request: web.Request) -> web.Response:
+    data = await request.json()
+    user_id = len(request.app["users"]) + 1
+    request.app["users"][user_id] = {**data, "id": user_id}
+    return web.json_response({"id": user_id}, status=201)
+
+
+async def get_user(request: web.Request) -> web.Response:
+    user_id = int(request.match_info["user_id"])
+    try:
+        user = request.app["users"][user_id]
+        return web.json_response(user)
+    except KeyError:
+        return web.json_response({"message": "Not found"}, status=404)
+
+
+async def update_user(request: web.Request) -> web.Response:
+    user_id = int(request.match_info["user_id"])
+    try:
+        user = request.app["users"][user_id]
+        data = await request.json()
+        user["username"] = data["username"]
+        return web.json_response(user)
+    except KeyError:
+        return web.json_response({"message": "Not found"}, status=404)
+
+
 get_payload = payload
 path_variable = success
 invalid = success

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -248,12 +248,12 @@ def complex_schema(testdir):
     return str(root)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def swagger_20(simple_schema):
     return schemathesis.from_dict(simple_schema)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def openapi_30():
     raw = make_schema("simple_openapi.yaml")
     return schemathesis.from_dict(raw)

--- a/test/specs/openapi/test_expressions.py
+++ b/test/specs/openapi/test_expressions.py
@@ -1,0 +1,165 @@
+import json
+
+import pytest
+import requests
+from hypothesis import given
+from hypothesis import strategies as st
+
+from schemathesis import Case
+from schemathesis.models import Endpoint
+from schemathesis.specs.openapi import expressions
+from schemathesis.specs.openapi.expressions.errors import RuntimeExpressionError
+from schemathesis.specs.openapi.expressions.lexer import Token
+from schemathesis.specs.openapi.expressions.pointers import resolve
+
+DOCUMENT = {"foo": ["bar", "baz"], "": 0, "a/b": 1, "c%d": 2, "e^f": 3, "g|h": 4, "i\\j": 5, 'k"l': 6, " ": 7, "m~n": 8}
+
+
+@pytest.fixture(scope="module")
+def endpoint():
+    return Endpoint("/users/{user_id}", "GET", None, None, base_url="http://127.0.0.1:8080/api")
+
+
+@pytest.fixture(scope="module")
+def case(endpoint):
+    return Case(
+        endpoint,
+        path_parameters={"user_id": 5},
+        query={"username": "foo"},
+        headers={"X-Token": "secret"},
+        body={"a": 1},
+    )
+
+
+@pytest.fixture(scope="module")
+def response():
+    response = requests.Response()
+    response._content = json.dumps(DOCUMENT).encode()
+    response.status_code = 200
+    response.headers["Content-Type"] = "application/json"
+    response.headers["X-Response"] = "Y"
+    return response
+
+
+@pytest.fixture(scope="module")
+def context(case, response):
+    return expressions.ExpressionContext(response=response, case=case)
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    (
+        ("", ""),
+        ("foo", "foo"),
+        ("$url", "http://127.0.0.1:8080/api/users/5?username=foo"),
+        ("$method", "GET"),
+        ("$statusCode", "200"),
+        ("ID_{$method}", "ID_GET"),
+        ("$request.query.username", "foo"),
+        ("spam_{$request.query.username}_baz_{$request.query.username}", "spam_foo_baz_foo"),
+        ("spam_{$request.path.user_id}", "spam_5"),
+        ("spam_{$request.header.X-Token}", "spam_secret"),
+        ("$request.body", '{"a": 1}'),
+        ("$request.body#/a", 1),
+        ("spam_{$response.header.X-Response}", "spam_Y"),
+        ("$response.body#/foo/0", "bar"),
+        ("$response.body#/g|h", 4),
+        (42, 42),
+        ("$response.body", json.dumps(DOCUMENT)),
+        ("ID_{$response.body#/g|h}", "ID_4"),
+        ("ID_{$response.body#/g|h}_{$response.body#/a~1b}", "ID_4_1"),
+    ),
+)
+def test_evaluate(context, expr, expected):
+    assert expressions.evaluate(expr, context) == expected
+
+
+@pytest.mark.parametrize(
+    "expr",
+    (
+        "$u",
+        "$urlfoo",
+        "{{$foo.$bar}}",
+        "{$foo",
+        "$foo}",
+        "$request..",
+        "$request.unknown",
+        "$request.body.unknown",
+        "$response..",
+        "$response.unknown",
+        "$response.body.something",
+        "$response.header..",
+        "$response}",
+    ),
+)
+def test_invalid_expression(context, expr):
+    with pytest.raises(RuntimeExpressionError):
+        expressions.evaluate(expr, context)
+
+
+@given(expr=(st.text() | (st.lists(st.sampled_from([".", "}", "{", "$"]) | st.text()).map("".join))))
+def test_random_expression(expr):
+    try:
+        expressions.evaluate(expr, context)
+    except RuntimeExpressionError:
+        pass
+
+
+def test_non_json_serializable_body(endpoint, response):
+    case = Case(endpoint, body={"a": b"content"})
+    context = expressions.ExpressionContext(response=response, case=case)
+    with pytest.raises(RuntimeExpressionError, match="^The request body is not JSON-serializable$"):
+        expressions.evaluate("$request.body", context=context)
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    (
+        ("$url", [Token.variable("$url")]),
+        ("foo", [Token.string("foo")]),
+        ("foo1", [Token.string("foo1")]),
+        ("{}", [Token.lbracket(), Token.rbracket()]),
+        ("{foo}", [Token.lbracket(), Token.string("foo"), Token.rbracket()]),
+        ("{$foo}", [Token.lbracket(), Token.variable("$foo"), Token.rbracket()]),
+        (
+            "foo{$bar}spam",
+            [Token.string("foo"), Token.lbracket(), Token.variable("$bar"), Token.rbracket(), Token.string("spam")],
+        ),
+        ("$foo.bar", [Token.variable("$foo"), Token.dot(), Token.string("bar")]),
+        ("$foo.$bar", [Token.variable("$foo"), Token.dot(), Token.variable("$bar")]),
+        (
+            "{$foo.$bar}",
+            [Token.lbracket(), Token.variable("$foo"), Token.dot(), Token.variable("$bar"), Token.rbracket()],
+        ),
+        (
+            "$request.body#/foo/bar",
+            [Token.variable("$request"), Token.dot(), Token.string("body"), Token.pointer("#/foo/bar")],
+        ),
+    ),
+)
+def test_lexer(expr, expected):
+    assert list(expressions.lexer.tokenize(expr)) == expected
+
+
+@pytest.mark.parametrize(
+    "pointer, expected",
+    (
+        ("", DOCUMENT),
+        ("abc", None),
+        ("/foo/123", None),
+        ("/foo", ["bar", "baz"]),
+        ("/foo/0", "bar"),
+        ("/", 0),
+        ("/a~1b", 1),
+        ("/c%d", 2),
+        ("/c%d/foo", None),
+        ("/e^f", 3),
+        ("/g|h", 4),
+        ("/i\\j", 5),
+        ('/k"l', 6),
+        ("/ ", 7),
+        ("/m~0n", 8),
+    ),
+)
+def test_pointer(pointer, expected):
+    assert resolve(DOCUMENT, pointer) == expected

--- a/test/specs/openapi/test_links.py
+++ b/test/specs/openapi/test_links.py
@@ -1,0 +1,191 @@
+import json
+from unittest.mock import ANY
+
+import pytest
+import requests
+
+import schemathesis
+from schemathesis.models import Case, Endpoint
+from schemathesis.specs.openapi.links import Link
+from schemathesis.stateful import ParsedData
+
+ENDPOINT = Endpoint(
+    path="/api/users/{user_id}",
+    method="GET",
+    definition=ANY,
+    schema=ANY,
+    base_url=ANY,
+    path_parameters={
+        "properties": {"user_id": {"in": "path", "name": "user_id", "type": "integer"}},
+        "additionalProperties": False,
+        "type": "object",
+        "required": ["user_id"],
+    },
+    query={
+        "properties": {
+            "code": {"in": "query", "name": "code", "type": "integer"},
+            "user_id": {"in": "query", "name": "user_id", "type": "integer"},
+            "common": {"in": "query", "name": "common", "type": "integer"},
+        },
+        "additionalProperties": False,
+        "type": "object",
+        "required": ["code", "user_id", "common"],
+    },
+)
+LINK = Link(
+    name="GetUserByUserId",
+    endpoint=ENDPOINT,
+    parameters={"path.user_id": "$response.body#/id", "query.user_id": "$response.body#/id"},
+)
+
+
+@pytest.fixture(scope="module")
+def case():
+    return Case(ENDPOINT)
+
+
+@pytest.fixture(scope="module")
+def response():
+    response = requests.Response()
+    response._content = b'{"id": 5}'
+    response.status_code = 201
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    (
+        (
+            "/api/users/",
+            [
+                LINK,
+                Link(
+                    name="UpdateUserById",
+                    endpoint=ANY,
+                    parameters={"user_id": "$response.body#/id"},
+                    request_body={"username": "foo"},
+                ),
+            ],
+        ),
+        ("/unknown", []),
+    ),
+)
+@pytest.mark.endpoints("create_user", "get_user", "update_user")
+def test_get_links(base_url, schema_url, url, expected):
+    schema = schemathesis.from_uri(schema_url)
+    response = requests.post(f"{base_url}{url}", json={"username": "TEST"})
+    assert schema.endpoints["/api/users/"]["POST"].get_stateful_tests(response, "links") == expected
+
+
+def test_parse(case, response):
+    assert LINK.parse(case, response) == ParsedData({"path.user_id": 5, "query.user_id": 5})
+
+
+EXPECTED_PATH_PARAMETERS = [
+    {
+        "additionalProperties": False,
+        "properties": {"user_id": {"const": 1, "in": "path", "name": "user_id", "type": "integer"}},
+        "required": ["user_id"],
+        "type": "object",
+    },
+    {
+        "additionalProperties": False,
+        "properties": {"user_id": {"const": 3, "in": "path", "name": "user_id", "type": "integer"}},
+        "required": ["user_id"],
+        "type": "object",
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "value, path_parameters, query",
+    (
+        (
+            [{"path.user_id": 1, "query.user_id": 2, "code": 7}, {"path.user_id": 3, "query.user_id": 4, "code": 5}],
+            EXPECTED_PATH_PARAMETERS,
+            [
+                {
+                    "additionalProperties": False,
+                    "properties": {
+                        "code": {"const": 5, "in": "query", "name": "code", "type": "integer"},
+                        "user_id": {"const": 4, "in": "query", "name": "user_id", "type": "integer"},
+                        "common": {"in": "query", "name": "common", "type": "integer"},
+                    },
+                    "required": ["code", "user_id", "common"],
+                    "type": "object",
+                },
+                {
+                    "additionalProperties": False,
+                    "properties": {
+                        "code": {"const": 7, "in": "query", "name": "code", "type": "integer"},
+                        "user_id": {"const": 2, "in": "query", "name": "user_id", "type": "integer"},
+                        "common": {"in": "query", "name": "common", "type": "integer"},
+                    },
+                    "required": ["code", "user_id", "common"],
+                    "type": "object",
+                },
+            ],
+        ),
+        (
+            [{"path.user_id": 1}, {"path.user_id": 3}],
+            EXPECTED_PATH_PARAMETERS,
+            [
+                {
+                    "additionalProperties": False,
+                    "properties": {
+                        "code": {"in": "query", "name": "code", "type": "integer"},
+                        "user_id": {"in": "query", "name": "user_id", "type": "integer"},
+                        "common": {"in": "query", "name": "common", "type": "integer"},
+                    },
+                    "required": ["code", "user_id", "common"],
+                    "type": "object",
+                },
+                {
+                    "additionalProperties": False,
+                    "properties": {
+                        "code": {"in": "query", "name": "code", "type": "integer"},
+                        "user_id": {"in": "query", "name": "user_id", "type": "integer"},
+                        "common": {"in": "query", "name": "common", "type": "integer"},
+                    },
+                    "required": ["code", "user_id", "common"],
+                    "type": "object",
+                },
+            ],
+        ),
+    ),
+)
+def test_make_endpoint(value, path_parameters, query):
+    endpoint = LINK.make_endpoint(list(map(ParsedData, value)))
+    assert len(endpoint.path_parameters) == 1
+    assert sorted(endpoint.path_parameters["anyOf"], key=json.dumps) == path_parameters
+    assert len(endpoint.query) == 1
+    assert sorted(endpoint.query["anyOf"], key=json.dumps) == query
+
+
+def test_make_endpoint_single():
+    endpoint = LINK.make_endpoint([ParsedData({"path.user_id": 1, "query.user_id": 2, "code": 7})])
+    assert endpoint.path_parameters == {
+        "properties": {"user_id": {"in": "path", "name": "user_id", "type": "integer", "const": 1}},
+        "additionalProperties": False,
+        "type": "object",
+        "required": ["user_id"],
+    }
+    assert endpoint.query == {
+        "properties": {
+            "code": {"in": "query", "name": "code", "type": "integer", "const": 7},
+            "user_id": {"in": "query", "name": "user_id", "type": "integer", "const": 2},
+            "common": {"in": "query", "name": "common", "type": "integer"},
+        },
+        "additionalProperties": False,
+        "type": "object",
+        "required": ["code", "user_id", "common"],
+    }
+
+
+@pytest.mark.parametrize("parameter", ("wrong.id", "unknown", "header.id"))
+def test_make_endpoint_invalid_location(parameter):
+    with pytest.raises(
+        ValueError, match=f"Parameter `{parameter}` is not defined in endpoint GET /api/users/{{user_id}}"
+    ):
+        LINK.make_endpoint([ParsedData({parameter: 4})])

--- a/test/specs/openapi/test_schemas.py
+++ b/test/specs/openapi/test_schemas.py
@@ -1,0 +1,18 @@
+import pytest
+
+from schemathesis.models import Endpoint
+
+
+@pytest.mark.endpoints("get_user", "update_user")
+def test_get_endpoint_via_remote_reference(swagger_20, schema_url):
+    resolved = swagger_20.get_endpoint_by_reference(f"{schema_url}#/paths/~1users~1{{user_id}}/patch")
+    assert isinstance(resolved, Endpoint)
+    assert resolved.path == "/v1/users/{user_id}"
+    assert resolved.method == "PATCH"
+    # Via common parameters for all methods
+    assert resolved.query == {
+        "properties": {"common": {"in": "query", "name": "common", "type": "integer"},},
+        "additionalProperties": False,
+        "type": "object",
+        "required": ["common"],
+    }

--- a/test/test_schemas.py
+++ b/test/test_schemas.py
@@ -110,3 +110,22 @@ def test_schema_parsing_error(simple_schema, error_type, validate_schema, expect
     with pytest.raises(expected_exception):
         schema = schemathesis.from_dict(raw_schema, validate_schema=validate_schema)
         list(schema.get_all_endpoints())
+
+
+RESPONSES = {"responses": {"200": {"description": "OK"}}}
+SCHEMA = {
+    "openapi": "3.0.2",
+    "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+    "paths": {
+        "/foo": {"get": {"operationId": "getFoo", **RESPONSES}, "post": {"operationId": "postFoo", **RESPONSES}},
+        "/bar": {"get": {"operationId": "getBar", **RESPONSES}, "post": {"operationId": "postBar", **RESPONSES}},
+    },
+}
+
+
+@pytest.mark.parametrize("operation_id, path, method", (("getFoo", "/foo", "GET"), ("postBar", "/bar", "POST"),))
+def test_get_endpoint_by_operation_id(operation_id, path, method):
+    schema = schemathesis.from_dict(SCHEMA)
+    endpoint = schema.get_endpoint_by_operation_id(operation_id)
+    assert endpoint.path == path
+    assert endpoint.method == method

--- a/test/test_stateful.py
+++ b/test/test_stateful.py
@@ -1,0 +1,11 @@
+import pytest
+
+from schemathesis.stateful import ParsedData
+from schemathesis.utils import NOT_SET
+
+
+@pytest.mark.parametrize(
+    "parameters, body", (({"a": 1}, None), ({"a": 1}, NOT_SET), ({"a": 1}, {"value": 1}), ({"a": 1}, [1, 2, 3]))
+)
+def test_hashable(parameters, body):
+    hash(ParsedData(parameters, body))


### PR DESCRIPTION
Very early PoC PR to keep track of TODOs & comment on code

TODO:

- [x] Quite a lot of small things in comments
- [x] Threaded runners support
- [x] WSGI support
- [x] Fix coverage
- [x] Docs
- [x] More docstrings
- [x] complete runtime expressions support. https://swagger.io/docs/specification/links/#runtime-expressions 
- [x] Support for location prefixes in links when two or more parameters have the same name (`query.id`, `body.id`, etc)
- [x] What if the parsed expression is not a string?
- [x] `$response` variable support
- [x] JSON pointer support
- [x] Keep the same type inside runtime expressions
- [x] Hypothesis tests for runtime expressions
- [x] Entire body support in runtime expressions. How it should be done? JSON?
- [x] Error handling for runtime expressions (including unbalanced brackets)
- [x] Handle recursion
- [x] Handle CLI percentage properly
- [x] Deduplicate data samples
- [x] Add a distinguishable CLI name to the test generated by the `feedback` instance
- [x] Fix not needed newline in CLI output for threaded execution
- [x] Store endpoints by `operationId`
- [x] Resolve `operationRef` - local & external
- [x] Resolve links behind references
- [x] CLI option to enable links. E.g. `--stateful=links`
- [x] Proper support for `requestBody`
- [x] handle empty `parameters`
- [x] gather common parameters when resolving operation by `operationRef`
- [x] test for resolving external reference in `operationRef`
- [x] Configurable recursion limit + test
- [x] non JSON payload in `request.body`

In the future:
- `server` keyword overriding

Maybe the CLI output could look like this:

```
POST /api/users/ . 
  -> GET /api/users/{user_id} .
  -> PUT /api/users/{user_id} .
       -> DELETE /api/users/{user_id} .
```

So it is clear what is the dependency tree