### PR TITLE
fix: on CLI mode , `hooks` file existence in cwd ,but ModuleNotFoundE…

### DIFF
--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import traceback
 from enum import Enum
@@ -281,6 +282,7 @@ def get_output_handler(workers_num: int) -> EventHandler:
 def load_hook(module_name: str) -> None:
     """Load the given hook by importing it."""
     try:
+        sys.path.extend([os.getcwd()])  # fix ModuleNotFoundError  module in cwd
         __import__(module_name)
     except Exception:
         click.secho("An exception happened during the hook loading:\n", fg="red")

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -781,6 +781,23 @@ def test_pre_run_hook_invalid(testdir, cli):
     assert lines[9] == "Aborted!"
 
 
+def test_pre_run_hook_module_not_found(testdir, cli):
+    import os, sys
+
+    testdir.makepyfile(hook="1 / 0")
+    result = cli.main("--pre-run", "hook", "run", "http://127.0.0.1:1")
+
+    assert os.getcwd() in sys.path
+
+    # Then CLI run should fail
+    assert result.exit_code == ExitCode.TESTS_FAILED
+    assert "ModuleNotFoundError" not in result.stdout
+    lines = result.stdout.strip().split("\n")
+    assert lines[0] == "An exception happened during the hook loading:"
+    assert lines[7] == "ZeroDivisionError: division by zero"
+    assert lines[9] == "Aborted!"
+
+
 @pytest.fixture()
 def new_check(testdir, cli):
     module = testdir.make_importable_pyfile(


### PR DESCRIPTION
## To Reproduce

Hooks definition in `myproject/hooks.py`

```bash
|-- myproject
|   |-- __init__.py
|   `-- hooks.py

````

than run schemathesis

```bash
schemathesis --pre-run myproject.hooks run http://127.0.0.1/openapi.yaml
```

Get an error

```python
ModuleNotFoundError: No module named 'myproject'
```
## Cause
on CLI mode, cwd not in `sys.path`

-----

The original test case [/test/cli/test_commands.py#L771](https://github.com/kiwicom/schemathesis/blob/master/test/cli/test_commands.py#L771) ,  
Test passed  may be because called `make_importable` and `module._ensuresyspath` changed `sys.path`

So I add  new testcase  [test/cli/test_commands.py#L784](https://github.com/dongfangtianyu/schemathesis/blob/master/test/cli/test_commands.py#L784)