### PR TITLE
fix: Partially generated explicit examples are always valid and can be used in requests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+Fixed
+~~~~~
+
+- Partially generated explicit examples are always valid and can be used in requests. `#582`_
+
 `1.6.1`_ - 2020-05-13
 ---------------------
 
@@ -1061,6 +1066,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#586: https://github.com/kiwicom/schemathesis/issues/586
+.. _#582: https://github.com/kiwicom/schemathesis/issues/582
 .. _#579: https://github.com/kiwicom/schemathesis/issues/579
 .. _#575: https://github.com/kiwicom/schemathesis/issues/575
 .. _#571: https://github.com/kiwicom/schemathesis/issues/571

--- a/src/schemathesis/_compat.py
+++ b/src/schemathesis/_compat.py
@@ -1,21 +1,4 @@
 # pylint: disable=unused-import
-from contextlib import contextmanager
-from typing import Generator
-from warnings import catch_warnings, simplefilter
-
-
-@contextmanager
-def handle_warnings() -> Generator[None, None, None]:
-    try:
-        from hypothesis.errors import NonInteractiveExampleWarning  # pylint: disable=import-outside-toplevel
-
-        with catch_warnings():
-            simplefilter("ignore", NonInteractiveExampleWarning)
-            yield
-    except ImportError:
-        yield
-
-
 try:
     from importlib import metadata
 except ImportError:

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -1,26 +1,7 @@
-import sys
-import warnings
-
 import hypothesis
 import pytest
-from hypothesis.errors import NonInteractiveExampleWarning
 
-from schemathesis._compat import handle_warnings
 from schemathesis._hypothesis import get_original_test
-
-
-def test_handle_warnings(recwarn):
-    with handle_warnings():
-        warnings.warn("Message", NonInteractiveExampleWarning)
-    assert not recwarn
-
-
-def test_handle_warnings_old_hypothesis(monkeypatch, recwarn):
-    # Assume that there is an import error - old hypothesis version
-    monkeypatch.setitem(sys.modules, "hypothesis.errors", None)
-    with handle_warnings():
-        warnings.warn("Message", NonInteractiveExampleWarning)
-    assert recwarn
 
 
 @pytest.mark.parametrize("version", ((4, 40, 0), (4, 42, 3)))

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,0 +1,40 @@
+import pytest
+from hypothesis import given
+
+import schemathesis
+from schemathesis._hypothesis import get_example
+
+
+@pytest.fixture(scope="module")
+def schema():
+    return schemathesis.from_dict(
+        {
+            "openapi": "3.0.2",
+            "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+            "servers": [{"url": "http://127.0.0.1:8081/{basePath}", "variables": {"basePath": {"default": "api"}}}],
+            "paths": {
+                "/success": {
+                    "get": {
+                        "parameters": [
+                            {"name": "anyKey", "in": "header", "schema": {"type": "string"},},
+                            {"name": "id", "in": "query", "schema": {"type": "string", "example": "1"},},
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+
+
+@pytest.mark.hypothesis_nested
+def test_examples_validity(schema, base_url):
+    strategy = get_example(schema.endpoints["/api/success"]["get"])
+
+    @given(case=strategy)
+    def test(case):
+        # Generated examples should have valid parameters
+        # E.g. headers should be latin-1 encodable
+        case.call(base_url=base_url)
+
+    test()

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -15,6 +15,7 @@ def make_endpoint(schema, **kwargs) -> Endpoint:
 
 
 @pytest.mark.parametrize("name", sorted(PARAMETERS))
+@pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
 def test_get_examples(name, swagger_20):
     example = {"name": "John"}
     endpoint = make_endpoint(
@@ -29,9 +30,10 @@ def test_get_examples(name, swagger_20):
             }
         },
     )
-    assert get_example(endpoint) == Case(endpoint, **{name: example})
+    assert get_example(endpoint).example() == Case(endpoint, **{name: example})
 
 
+@pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
 def test_no_body_in_get(swagger_20):
     endpoint = Endpoint(
         path="/api/success",
@@ -46,7 +48,7 @@ def test_no_body_in_get(swagger_20):
             "example": {"name": "John"},
         },
     )
-    assert get_example(endpoint).body is None
+    assert get_example(endpoint).example().body is None
 
 
 def test_invalid_body_in_get(swagger_20):
@@ -79,14 +81,6 @@ def test_invalid_body_in_get_disable_validation(simple_schema):
         assert case.body is not None
 
     test()
-
-
-def test_warning(swagger_20):
-    example = {"name": "John"}
-    endpoint = make_endpoint(swagger_20, query={"example": example})
-    with pytest.warns(None) as record:
-        assert get_example(endpoint) == Case(endpoint, query=example)
-    assert not record
 
 
 @pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")


### PR DESCRIPTION
Fixes #582 