### PR TITLE
feat: add_case hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ Session.vim
 .netrwhist
 *~
 
+#####=== VS Code ===#####
+.vscode/*
+
 #####=== JetBrains ===#####
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Added
 
 - Support for YAML files in references via HTTP & HTTP schemas. `#600`_
 - Stateful testing support via ``Open API links`` syntax. `#548`_
+- New ``add_case`` hook. `#458`_
 
 Changed
 ~~~~~~~
@@ -1124,6 +1125,7 @@ Fixed
 .. _#468: https://github.com/kiwicom/schemathesis/issues/468
 .. _#463: https://github.com/kiwicom/schemathesis/issues/463
 .. _#461: https://github.com/kiwicom/schemathesis/issues/461
+.. _#458: https://github.com/kiwicom/schemathesis/issues/458
 .. _#457: https://github.com/kiwicom/schemathesis/issues/457
 .. _#451: https://github.com/kiwicom/schemathesis/issues/451
 .. _#450: https://github.com/kiwicom/schemathesis/issues/450

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -188,3 +188,19 @@ With this simple handler only ``Done!`` will be displayed at the end of the test
 - Store logs in a custom format
 - Change the output visual style
 - Display additional information in the output
+
+``add_case``
+~~~~~~~~~~~~
+
+For each ``add_case`` hook and for each endpoint, we create an additional, duplicate test case. We pass the Case object from the duplicate test to the ``add_case`` hook.
+The user may change the Case object (and therefore the request data) before the request is sent to the server. The ``add_case`` allows the user to target specific
+behavior in the API by changing specific details of the duplicate request.
+
+.. code:: python
+
+    def add_case(context: HookContext, case: Case) -> Case:
+        case.headers["Content-Type"] = "application/json"
+        return case
+
+Note: A partial deep copy of the ``Case`` object is passed to each ``add_case`` hook. ``Case.endpoint.app`` is a reference to the original ``app``, 
+and ``Case.endpoint.schema`` is a shallow copy, so changes to these fields will be reflected in other tests.

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -230,6 +230,14 @@ def before_add_examples(context: HookContext, examples: List[Case]) -> None:
     """
 
 
+@HookDispatcher.register_spec([HookScope.GLOBAL])
+def add_case(context: HookContext, case: Case) -> Case:
+    """Creates an additional test per endpoint.
+
+    Called before request is sent with a copy of the original case object.
+    """
+
+
 GLOBAL_HOOK_DISPATCHER = HookDispatcher(scope=HookScope.GLOBAL)
 dispatch = GLOBAL_HOOK_DISPATCHER.dispatch
 get_all_by_name = GLOBAL_HOOK_DISPATCHER.get_all_by_name

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -4,6 +4,7 @@ import datetime
 import http
 from collections import Counter
 from contextlib import contextmanager
+from copy import deepcopy
 from enum import IntEnum
 from logging import LogRecord
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterator, List, Optional, Sequence, Tuple, Union, cast
@@ -198,6 +199,17 @@ class Case:
         prepared = requests.Session().prepare_request(request)  # type: ignore
         return prepared.url
 
+    def partial_deepcopy(self) -> "Case":
+        return self.__class__(
+            endpoint=self.endpoint.partial_deepcopy(),
+            path_parameters=deepcopy(self.path_parameters),
+            headers=deepcopy(self.headers),
+            cookies=deepcopy(self.cookies),
+            query=deepcopy(self.query),
+            body=deepcopy(self.body),
+            form_data=deepcopy(self.form_data),
+        )
+
 
 def is_multipart(item: Optional[Body]) -> bool:
     """A poor detection if the body should be a multipart request.
@@ -274,6 +286,22 @@ class Endpoint:
 
     def get_stateful_tests(self, response: GenericResponse, stateful: Optional[str]) -> Sequence["StatefulTest"]:
         return self.schema.get_stateful_tests(response, self, stateful)
+
+    def partial_deepcopy(self) -> "Endpoint":
+        return self.__class__(
+            path=self.path,  # string, immutable
+            method=self.method,  # string, immutable
+            definition=deepcopy(self.definition),
+            schema=self.schema.clone(),  # shallow copy
+            app=self.app,  # not deepcopyable
+            base_url=self.base_url,  # string, immutable
+            path_parameters=deepcopy(self.path_parameters),
+            headers=deepcopy(self.path_parameters),
+            cookies=deepcopy(self.cookies),
+            query=deepcopy(self.query),
+            body=deepcopy(self.body),
+            form_data=deepcopy(self.form_data),
+        )
 
 
 class Status(IntEnum):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from test.utils import SIMPLE_PATH
 
 import pytest
@@ -56,6 +57,36 @@ def test_call(override, base_url, swagger_20):
     with pytest.warns(None) as records:
         del response
     assert not records
+
+
+def test_case_partial_deepcopy(swagger_20):
+    endpoint = Endpoint("/example/path", "GET", {}, swagger_20)
+    original_case = Case(
+        endpoint=endpoint,
+        path_parameters={"test": "test"},
+        headers={"Content-Type": "application/json"},
+        cookies={"TOKEN": "secret"},
+        query={"a": 1},
+        body={"b": 1},
+        form_data={"first": "John", "last": "Doe"},
+    )
+
+    copied_case = original_case.partial_deepcopy()
+    copied_case.endpoint.path = "/overwritten/path"
+    copied_case.path_parameters["test"] = "overwritten"
+    copied_case.headers["Content-Type"] = "overwritten"
+    copied_case.cookies["TOKEN"] = "overwritten"
+    copied_case.query["a"] = "overwritten"
+    copied_case.body["b"] = "overwritten"
+    copied_case.form_data["first"] = "overwritten"
+
+    assert original_case.endpoint.path == "/example/path"
+    assert original_case.path_parameters["test"] == "test"
+    assert original_case.headers["Content-Type"] == "application/json"
+    assert original_case.cookies["TOKEN"] == "secret"
+    assert original_case.query["a"] == 1
+    assert original_case.body["b"] == 1
+    assert original_case.form_data["first"] == "John"
 
 
 schema = schemathesis.from_path(SIMPLE_PATH)


### PR DESCRIPTION
Related issue: #458 

Updates:
- Adds `add_case` hook. For each `add_case` hook and for each endpoint, an additional, duplicate test is created, and the associated Case object is passed to hook before the request is sent to the server.

Purpose:
- Used to create targeted requests. The duplicate Case objects may be altered in specific ways to target specific behavior in the API. User may test, for example, how the API behavior is affected when the rest of the request stays the same but the `Content-Type` header is set to `application/json; charset=utf8`.

Tests:
- Adds a test to ensure that one additional Case object is created for each endpoint.
- Add test to ensure that mutation of a Case in an `add_case` hook does not affect other Cases.
- Adds a test to ensure the output is formatted correctly when the additional cases fail a check.
- Adds a test to ensure `Case.partial_deepcopy` deep copies expected fields.

Related PR: #564 

The related PR also creates additional tests and passes the associated strategy to the user for updates. This `add_case` hook is the behavior I meant to implement initially, but @Stranger6667 you mentioned that #564 may provide some good utility. I'm happy to finish and clean up #564 as well if you think it would be a good addition to the project.

Related issue: #458 