### PR TITLE
fix: Support for a colon symbol ('':') inside of a header value passed via CLI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Support for a colon symbol (``:``) inside of a header value passed via CLI. `#596`_
+
 `1.6.2`_ - 2020-05-15
 ---------------------
 
@@ -1069,6 +1074,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#596: https://github.com/kiwicom/schemathesis/issues/596
 .. _#586: https://github.com/kiwicom/schemathesis/issues/586
 .. _#582: https://github.com/kiwicom/schemathesis/issues/582
 .. _#579: https://github.com/kiwicom/schemathesis/issues/579

--- a/src/schemathesis/cli/callbacks.py
+++ b/src/schemathesis/cli/callbacks.py
@@ -78,7 +78,7 @@ def validate_headers(
     headers = {}
     for header in raw_value:
         with reraise_format_error(header):
-            key, value = header.split(":")
+            key, value = header.split(":", maxsplit=1)
         value = value.lstrip()
         key = key.strip()
         if not key:

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -1163,3 +1163,12 @@ def test_fast_api_fixup(testdir, cli, base_url, fast_api_schema, fast_api_fixup,
     schema_file = testdir.makefile(".yaml", schema=yaml.dump(fast_api_schema))
     result = cli.run(str(schema_file), f"--base-url={base_url}", "--hypothesis-max-examples=1", f"--fixups={fixup}")
     assert result.exit_code == ExitCode.OK, result.stdout
+
+
+@pytest.mark.endpoints("success")
+def test_colon_in_headers(cli, schema_url, app):
+    header = "X-FOO"
+    value = "bar:spam"
+    result = cli.run(schema_url, f"--header={header}:{value}")
+    assert result.exit_code == ExitCode.OK
+    assert app["incoming_requests"][0].headers[header] == value


### PR DESCRIPTION
Fixes #596