### PR TITLE
feat: Support for parameters serialization formats in Open API 2 / 3

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Added
 - Support for YAML files in references via HTTP & HTTP schemas. `#600`_
 - Stateful testing support via ``Open API links`` syntax. `#548`_
 - New ``add_case`` hook. `#458`_
+- Support for parameters serialization formats in Open API 2 / 3. For example ``pipeDelimited`` or ``deepObject``. `#599`_
 
 Changed
 ~~~~~~~
@@ -1093,6 +1094,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#600: https://github.com/kiwicom/schemathesis/issues/600
+.. _#599: https://github.com/kiwicom/schemathesis/issues/599
 .. _#596: https://github.com/kiwicom/schemathesis/issues/596
 .. _#586: https://github.com/kiwicom/schemathesis/issues/586
 .. _#582: https://github.com/kiwicom/schemathesis/issues/582

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -287,6 +287,12 @@ class Endpoint:
     def get_stateful_tests(self, response: GenericResponse, stateful: Optional[str]) -> Sequence["StatefulTest"]:
         return self.schema.get_stateful_tests(response, self, stateful)
 
+    def get_hypothesis_conversions(self, location: str) -> Optional[Callable]:
+        definitions = [item for item in self.definition.raw.get("parameters", []) if item["in"] == location]
+        if definitions:
+            return self.schema.get_hypothesis_conversion(definitions)
+        return None
+
     def partial_deepcopy(self) -> "Endpoint":
         return self.__class__(
             path=self.path,  # string, immutable

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -8,7 +8,7 @@ Their responsibilities:
 They give only static definitions of endpoints.
 """
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, Generator, Iterator, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Sequence, Tuple, Union
 
 import attr
 import hypothesis
@@ -65,6 +65,9 @@ class BaseSchema(Mapping):
         self, response: GenericResponse, endpoint: Endpoint, stateful: Optional[str]
     ) -> Sequence[StatefulTest]:
         """Get a list of additional tests, that should be executed after this response from the endpoint."""
+        raise NotImplementedError
+
+    def get_hypothesis_conversion(self, definitions: List[Dict[str, Any]]) -> Optional[Callable]:
         raise NotImplementedError
 
     def get_all_tests(

--- a/src/schemathesis/specs/openapi/serialization.py
+++ b/src/schemathesis/specs/openapi/serialization.py
@@ -1,0 +1,296 @@
+import functools
+from typing import Any, Callable, Dict, Generator, List, Optional
+
+Generated = Dict[str, Any]
+Definition = Dict[str, Any]
+DefinitionList = List[Definition]
+MapFunction = Callable[[Generated], Generated]
+
+
+def compose(*functions: Callable) -> Callable:
+    """Compose multiple functions into a single one."""
+
+    def noop(x: Any) -> Any:
+        return x
+
+    return functools.reduce(lambda f, g: lambda x: f(g(x)), functions, noop)
+
+
+def make_serializer(
+    func: Callable[[DefinitionList], Generator[Optional[Callable], None, None]]
+) -> Callable[[DefinitionList], Optional[Callable]]:
+    """A maker function to avoid code duplication."""
+
+    def _wrapper(definitions: DefinitionList) -> Optional[Callable]:
+        conversions = list(func(definitions))
+        if conversions:
+            return compose(*[conv for conv in conversions if conv is not None])
+        return None
+
+    return _wrapper
+
+
+def _serialize_openapi3(definitions: DefinitionList) -> Generator[Optional[Callable], None, None]:
+    """Different collection styles for Open API 3.0."""
+    for definition in definitions:
+        name = definition["name"]
+        style = definition.get("style")
+        explode = definition.get("explode")
+        type_ = definition.get("schema", {}).get("type")
+        if definition["in"] == "path":
+            yield from _serialize_path_openapi3(name, type_, style, explode)
+        elif definition["in"] == "query":
+            yield from _serialize_query_openapi3(name, type_, style, explode)
+        elif definition["in"] == "header":
+            yield from _serialize_header_openapi3(name, type_, explode)
+        elif definition["in"] == "cookie":
+            yield from _serialize_cookie_openapi3(name, type_, explode)
+
+
+def _serialize_path_openapi3(
+    name: str, type_: str, style: Optional[str], explode: Optional[bool]
+) -> Generator[Optional[Callable], None, None]:
+    # pylint: disable=too-many-branches
+    if style == "simple":
+        if type_ == "object":
+            if explode is False:
+                yield comma_delimited_object(name)
+            if explode is True:
+                yield delimited_object(name)
+        if type_ == "array":
+            yield delimited(name, delimiter=",")
+    if style == "label":
+        if type_ == "object":
+            yield label_object(name, explode=explode)
+        elif type_ == "array":
+            yield label_array(name, explode=explode)
+        else:
+            yield label_primitive(name)
+    if style == "matrix":
+        if type_ == "object":
+            yield matrix_object(name, explode=explode)
+        elif type_ == "array":
+            yield matrix_array(name, explode=explode)
+        else:
+            yield matrix_primitive(name)
+
+
+def _serialize_query_openapi3(
+    name: str, type_: str, style: Optional[str], explode: Optional[bool]
+) -> Generator[Optional[Callable], None, None]:
+    if type_ == "object":
+        if style == "deepObject":
+            yield deep_object(name)
+        if style is None or style == "form":
+            if explode is False:
+                yield comma_delimited_object(name)
+            if explode is True:
+                yield extracted_object(name)
+    elif type_ == "array" and explode is False:
+        if style == "pipeDelimited":
+            yield delimited(name, delimiter="|")
+        if style == "spaceDelimited":
+            yield delimited(name, delimiter=" ")
+        if style is None or style == "form":  # "form" is the default style
+            yield delimited(name, delimiter=",")
+
+
+def _serialize_header_openapi3(
+    name: str, type_: str, explode: Optional[bool]
+) -> Generator[Optional[Callable], None, None]:
+    # Header parameters always use the "simple" style, that is, comma-separated values
+    if type_ == "array":
+        yield delimited(name, delimiter=",")
+    if type_ == "object":
+        if explode is False:
+            yield comma_delimited_object(name)
+        if explode is True:
+            yield delimited_object(name)
+
+
+def _serialize_cookie_openapi3(
+    name: str, type_: str, explode: Optional[bool]
+) -> Generator[Optional[Callable], None, None]:
+    # Cookie parameters always use the "form" style
+    if explode and type_ in ("array", "object"):
+        # `explode=true` doesn't make sense
+        # I.e. we can't create multiple values for the same cookie
+        # We use the same behavior as in the examples - https://swagger.io/docs/specification/serialization/
+        # The item is removed
+        yield nothing(name)
+    if explode is False:
+        if type_ == "array":
+            yield delimited(name, delimiter=",")
+        if type_ == "object":
+            yield comma_delimited_object(name)
+
+
+def _serialize_swagger2(definitions: DefinitionList) -> Generator[Optional[Callable], None, None]:
+    """Different collection formats for Open API 2.0."""
+    for definition in definitions:
+        name = definition["name"]
+        collection_format = definition.get("collectionFormat", "csv")
+        type_ = definition.get("type")
+        if definition["in"] != "body" and type_ in ("array", "object"):
+            if collection_format == "csv":
+                yield delimited(name, delimiter=",")
+            if collection_format == "ssv":
+                yield delimited(name, delimiter=" ")
+            if collection_format == "tsv":
+                yield delimited(name, delimiter="\t")
+            if collection_format == "pipes":
+                yield delimited(name, delimiter="|")
+
+
+serialize_openapi3_parameters = make_serializer(_serialize_openapi3)
+serialize_swagger2_parameters = make_serializer(_serialize_swagger2)
+
+
+def conversion(func: Callable[..., None]) -> Callable:
+    def _wrapper(name: str, **kwargs: Any) -> MapFunction:
+        def _map(item: Generated) -> Generated:
+            if name in item:
+                func(item, name, **kwargs)
+            return item
+
+        return _map
+
+    return _wrapper
+
+
+def make_delimited(data: Dict[str, Any], delimiter: str = ",") -> str:
+    return delimiter.join(f"{key}={value}" for key, value in data.items())
+
+
+@conversion
+def delimited(item: Generated, name: str, delimiter: str) -> None:
+    item[name] = delimiter.join(item[name])
+
+
+@conversion
+def deep_object(item: Generated, name: str) -> None:
+    """Serialize an object with `deepObject` style.
+
+    id={"role": "admin", "firstName": "Alex"} => id[role]=admin&id[firstName]=Alex
+    """
+    generated = item.pop(name)
+    item.update({f"{name}[{key}]": value for key, value in generated.items()})
+
+
+@conversion
+def comma_delimited_object(item: Generated, name: str) -> None:
+    item[name] = ",".join(map(str, sum(item[name].items(), ())))
+
+
+@conversion
+def delimited_object(item: Generated, name: str) -> None:
+    item[name] = make_delimited(item[name])
+
+
+@conversion
+def extracted_object(item: Generated, name: str) -> None:
+    """Merge a child node to to the parent one."""
+    generated = item.pop(name)
+    item.update(generated)
+
+
+@conversion
+def label_primitive(item: Generated, name: str) -> None:
+    """Serialize a primitive value with the `label` style.
+
+    5 => ".5"
+    """
+    item[name] = f".{item[name]}"
+
+
+@conversion
+def label_array(item: Generated, name: str, explode: Optional[bool]) -> None:
+    """Serialize an array with the `label` style.
+
+    Explode=True
+
+        id=[3, 4, 5] => ".3.4.5"
+
+    Explode=False
+
+        id=[3, 4, 5] => ".3,4,5"
+    """
+    if explode:
+        delimiter = "."
+    else:
+        delimiter = ","
+    item[name] = f".{delimiter.join(item[name])}"
+
+
+@conversion
+def label_object(item: Generated, name: str, explode: Optional[bool]) -> None:
+    """Serialize an object with the `label` style.
+
+    Explode=True
+
+        id={"role": "admin", "firstName": "Alex"} => ".role=admin.firstName=Alex"
+
+    Explode=False
+
+        id={"role": "admin", "firstName": "Alex"} => ".role=admin,firstName,Alex"
+    """
+    if explode:
+        new = make_delimited(item[name], ".")
+    else:
+        object_items = map(str, sum(item[name].items(), ()))
+        new = ",".join(object_items)
+    item[name] = f".{new}"
+
+
+@conversion
+def matrix_primitive(item: Generated, name: str) -> None:
+    """Serialize a primitive value with the `matrix` style.
+
+    5 => ";id=5"
+    """
+    item[name] = f";{name}={item[name]}"
+
+
+@conversion
+def matrix_array(item: Generated, name: str, explode: Optional[bool]) -> None:
+    """Serialize an array with the `matrix` style.
+
+    Explode=True
+
+        id=[3, 4, 5] => ";id=3;id=4;id=5"
+
+    Explode=False
+
+        id=[3, 4, 5] => ";id=3,4,5"
+    """
+    if explode:
+        new = ";".join(f"{name}={value}" for value in item[name])
+    else:
+        new = ",".join(item[name])
+    item[name] = f";{new}"
+
+
+@conversion
+def matrix_object(item: Generated, name: str, explode: Optional[bool]) -> None:
+    """Serialize an object with the `matrix` style.
+
+    Explode=True
+
+        id={"role": "admin", "firstName": "Alex"} => ";role=admin;firstName=Alex"
+
+    Explode=False
+
+        id={"role": "admin", "firstName": "Alex"} => ";role=admin,firstName,Alex"
+    """
+    if explode:
+        new = make_delimited(item[name], ";")
+    else:
+        object_items = map(str, sum(item[name].items(), ()))
+        new = ",".join(object_items)
+    item[name] = f";{new}"
+
+
+@conversion
+def nothing(item: Generated, name: str) -> None:
+    """Remove a key from an item."""
+    item.pop(name, None)

--- a/test/specs/openapi/test_serializing.py
+++ b/test/specs/openapi/test_serializing.py
@@ -1,0 +1,282 @@
+from urllib.parse import quote, unquote
+
+import pytest
+from hypothesis import given
+
+import schemathesis
+from schemathesis.specs.openapi.serialization import conversion
+
+PRIMITIVE_SCHEMA = {"type": "integer", "enum": [1]}
+ARRAY_SCHEMA = {"type": "array", "enum": [["blue", "black", "brown"]]}
+OBJECT_SCHEMA = {
+    "additionalProperties": False,
+    "type": "object",
+    "properties": {
+        "r": {"type": "integer", "enum": [100]},  # "const" is not supported by Open API
+        "g": {"type": "integer", "enum": [200]},
+        "b": {"type": "integer", "enum": [150]},
+    },
+    "required": ["r", "g", "b"],
+}
+
+
+def chunks(items, n):
+    for i in range(0, len(items), n):
+        yield items[i : i + n]
+
+
+# Helpers to avoid dictionary ordering issues
+
+
+class Prefixed:
+    def __init__(self, instance, prefix=""):
+        self.instance = quote(instance)
+        self.prefix = quote(prefix)
+
+    def prepare(self, value):
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        if self.prefix:
+            if not other.startswith(self.prefix):
+                return False
+            prefix_length = len(self.prefix)
+            instance = self.instance[prefix_length:]
+            other = other[prefix_length:]
+        else:
+            instance = self.instance
+        return self.prepare(instance) == self.prepare(other)
+
+    def __str__(self):
+        return self.instance
+
+    def __repr__(self):
+        return f"'{self.instance}'"
+
+
+class CommaDelimitedObject(Prefixed):
+    def prepare(self, value):
+        items = unquote(value).split(",")
+        return dict(chunks(items, 2))
+
+
+class DelimitedObject(Prefixed):
+    def __init__(self, *args, delimiter=",", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.delimiter = delimiter
+
+    def prepare(self, value):
+        items = unquote(value).split(self.delimiter)
+        return dict(item.split("=") for item in items)
+
+
+def make_openapi_schema(*parameters):
+    return {
+        "openapi": "3.0.2",
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "paths": {
+            "/teapot": {
+                "get": {"summary": "Test", "parameters": list(parameters), "responses": {"200": {"description": "OK"}},}
+            }
+        },
+    }
+
+
+def assert_generates(raw_schema, expected, parameter):
+    schema = schemathesis.from_dict(raw_schema)
+
+    @given(case=schema["/teapot"]["GET"].as_strategy())
+    def test(case):
+        assert getattr(case, parameter) == expected
+
+    test()
+
+
+@pytest.mark.hypothesis_nested
+@pytest.mark.parametrize(
+    "schema, explode, style, expected",
+    (
+        # Based on examples from https://swagger.io/docs/specification/serialization/
+        (OBJECT_SCHEMA, True, "deepObject", {"color[r]": 100, "color[g]": 200, "color[b]": 150}),
+        (OBJECT_SCHEMA, True, "form", {"r": 100, "g": 200, "b": 150}),
+        (OBJECT_SCHEMA, False, "form", {"color": CommaDelimitedObject("r,100,g,200,b,150")}),
+        (ARRAY_SCHEMA, False, "pipeDelimited", {"color": "blue|black|brown"}),
+        (ARRAY_SCHEMA, True, "pipeDelimited", {"color": ["blue", "black", "brown"]}),
+        (ARRAY_SCHEMA, False, "spaceDelimited", {"color": "blue black brown"}),
+        (ARRAY_SCHEMA, True, "spaceDelimited", {"color": ["blue", "black", "brown"]}),
+        (ARRAY_SCHEMA, False, "form", {"color": "blue,black,brown"}),
+        (ARRAY_SCHEMA, True, "form", {"color": ["blue", "black", "brown"]}),
+    ),
+)
+def test_query_serialization_styles_openapi3(schema, explode, style, expected):
+    raw_schema = make_openapi_schema(
+        {"name": "color", "in": "query", "required": True, "schema": schema, "explode": explode, "style": style}
+    )
+    assert_generates(raw_schema, expected, "query")
+
+
+@pytest.mark.hypothesis_nested
+@pytest.mark.parametrize(
+    "schema, explode, expected",
+    (
+        (ARRAY_SCHEMA, True, {"X-Api-Key": "blue,black,brown"}),
+        (ARRAY_SCHEMA, False, {"X-Api-Key": "blue,black,brown"}),
+        (OBJECT_SCHEMA, True, {"X-Api-Key": DelimitedObject("r=100,g=200,b=150")}),
+        (OBJECT_SCHEMA, False, {"X-Api-Key": CommaDelimitedObject("r,100,g,200,b,150")}),
+    ),
+)
+def test_header_serialization_styles_openapi3(schema, explode, expected):
+    raw_schema = make_openapi_schema(
+        {"name": "X-Api-Key", "in": "header", "required": True, "schema": schema, "explode": explode}
+    )
+    assert_generates(raw_schema, expected, "headers")
+
+
+@pytest.mark.hypothesis_nested
+@pytest.mark.parametrize(
+    "schema, explode, expected",
+    (
+        (ARRAY_SCHEMA, True, {}),
+        (ARRAY_SCHEMA, False, {"SessionID": "blue,black,brown"}),
+        (OBJECT_SCHEMA, True, {}),
+        (OBJECT_SCHEMA, False, {"SessionID": CommaDelimitedObject("r,100,g,200,b,150")}),
+    ),
+)
+def test_cookie_serialization_styles_openapi3(schema, explode, expected):
+    raw_schema = make_openapi_schema(
+        {"name": "SessionID", "in": "cookie", "required": True, "schema": schema, "explode": explode}
+    )
+    assert_generates(raw_schema, expected, "cookies")
+
+
+@pytest.mark.hypothesis_nested
+@pytest.mark.parametrize(
+    "schema, style, explode, expected",
+    (
+        (ARRAY_SCHEMA, "simple", False, {"color": quote("blue,black,brown")}),
+        (ARRAY_SCHEMA, "simple", True, {"color": quote("blue,black,brown")}),
+        (OBJECT_SCHEMA, "simple", False, {"color": CommaDelimitedObject("r,100,g,200,b,150")}),
+        (OBJECT_SCHEMA, "simple", True, {"color": DelimitedObject("r=100,g=200,b=150")}),
+        (PRIMITIVE_SCHEMA, "label", False, {"color": quote(".1")}),
+        (PRIMITIVE_SCHEMA, "label", True, {"color": quote(".1")}),
+        (ARRAY_SCHEMA, "label", False, {"color": quote(".blue,black,brown")}),
+        (ARRAY_SCHEMA, "label", True, {"color": quote(".blue.black.brown")}),
+        (OBJECT_SCHEMA, "label", False, {"color": CommaDelimitedObject(".r,100,g,200,b,150", prefix=".")}),
+        (OBJECT_SCHEMA, "label", True, {"color": DelimitedObject(".r=100.g=200.b=150", prefix=".", delimiter=".")}),
+        (PRIMITIVE_SCHEMA, "matrix", False, {"color": quote(";color=1")}),
+        (PRIMITIVE_SCHEMA, "matrix", True, {"color": quote(";color=1")}),
+        (ARRAY_SCHEMA, "matrix", False, {"color": quote(";blue,black,brown")}),
+        (ARRAY_SCHEMA, "matrix", True, {"color": quote(";color=blue;color=black;color=brown")}),
+        (OBJECT_SCHEMA, "matrix", False, {"color": CommaDelimitedObject(";r,100,g,200,b,150", prefix=";")}),
+        (OBJECT_SCHEMA, "matrix", True, {"color": DelimitedObject(";r=100;g=200;b=150", prefix=";", delimiter=";")}),
+    ),
+)
+def test_path_serialization_styles_openapi3(schema, style, explode, expected):
+    raw_schema = {
+        "openapi": "3.0.2",
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "paths": {
+            "/teapot/{color}": {
+                "get": {
+                    "summary": "Test",
+                    "parameters": [
+                        {
+                            "name": "color",
+                            "in": "path",
+                            "required": True,
+                            "schema": schema,
+                            "style": style,
+                            "explode": explode,
+                        }
+                    ],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+    schema = schemathesis.from_dict(raw_schema)
+
+    @given(case=schema["/teapot/{color}"]["GET"].as_strategy())
+    def test(case):
+        assert case.path_parameters == expected
+
+    test()
+
+
+@pytest.mark.hypothesis_nested
+def test_query_serialization_styles_openapi_multiple_params():
+    raw_schema = make_openapi_schema(
+        {
+            "name": "color1",
+            "in": "query",
+            "required": True,
+            "schema": ARRAY_SCHEMA,
+            "explode": False,
+            "style": "pipeDelimited",
+        },
+        {
+            "name": "color2",
+            "in": "query",
+            "required": True,
+            "schema": ARRAY_SCHEMA,
+            "explode": False,
+            "style": "spaceDelimited",
+        },
+    )
+    assert_generates(raw_schema, {"color1": "blue|black|brown", "color2": "blue black brown"}, "query")
+
+
+@pytest.mark.hypothesis_nested
+@pytest.mark.parametrize(
+    "collection_format, expected",
+    (
+        ("csv", {"color": "blue,black,brown"}),
+        ("ssv", {"color": "blue black brown"}),
+        ("tsv", {"color": "blue\tblack\tbrown"}),
+        ("pipes", {"color": "blue|black|brown"}),
+        ("multi", {"color": ["blue", "black", "brown"]}),
+    ),
+)
+def test_query_serialization_styles_swagger2(collection_format, expected):
+    raw_schema = {
+        "swagger": "2.0",
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "host": "127.0.0.1:8888",
+        "basePath": "/",
+        "schemes": ["http"],
+        "produces": ["application/json"],
+        "paths": {
+            "/teapot": {
+                "get": {
+                    "parameters": [
+                        {
+                            "in": "query",
+                            "name": "color",
+                            "required": True,
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "collectionFormat": collection_format,
+                            "enum": [["blue", "black", "brown"]],
+                        }
+                    ],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+    assert_generates(raw_schema, expected, "query")
+
+
+@pytest.mark.parametrize("item, expected", (({}, {}), ({"key": 1}, {"key": "TEST"})))
+def test_item_is_missing(item, expected):
+    # When there is no key in the data
+
+    @conversion
+    def foo(data, name):
+        data[name] = "TEST"
+
+    foo("key")(item)
+
+    # Then the data should not be affected
+    # And should be otherwise
+    assert item == expected

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -7,11 +7,11 @@ import schemathesis
 from schemathesis import Case, register_string_format
 from schemathesis._hypothesis import PARAMETERS, get_case_strategy, get_example, is_valid_query
 from schemathesis.exceptions import InvalidSchema
-from schemathesis.models import Endpoint
+from schemathesis.models import Endpoint, EndpointDefinition
 
 
 def make_endpoint(schema, **kwargs) -> Endpoint:
-    return Endpoint("/users", "POST", definition={}, schema=schema, **kwargs)
+    return Endpoint("/users", "POST", definition=EndpointDefinition({}, "foo"), schema=schema, **kwargs)
 
 
 @pytest.mark.parametrize("name", sorted(PARAMETERS))
@@ -38,7 +38,7 @@ def test_no_body_in_get(swagger_20):
     endpoint = Endpoint(
         path="/api/success",
         method="GET",
-        definition={},
+        definition=EndpointDefinition({}, "foo"),
         schema=swagger_20,
         query={
             "required": ["name"],
@@ -55,7 +55,7 @@ def test_invalid_body_in_get(swagger_20):
     endpoint = Endpoint(
         path="/foo",
         method="GET",
-        definition={},
+        definition=EndpointDefinition({}, "foo"),
         schema=swagger_20,
         body={"required": ["foo"], "type": "object", "properties": {"foo": {"type": "string"}}},
     )
@@ -69,7 +69,7 @@ def test_invalid_body_in_get_disable_validation(simple_schema):
     endpoint = Endpoint(
         path="/foo",
         method="GET",
-        definition={},
+        definition=EndpointDefinition({}, "foo"),
         schema=schema,
         body={"required": ["foo"], "type": "object", "properties": {"foo": {"type": "string"}}},
     )
@@ -160,7 +160,7 @@ def test_valid_headers(base_url, swagger_20):
     endpoint = Endpoint(
         "/api/success",
         "GET",
-        definition={},
+        definition=EndpointDefinition({}, "foo"),
         schema=swagger_20,
         base_url=base_url,
         headers={

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -1,5 +1,6 @@
 import datetime
 from copy import deepcopy
+from urllib.parse import quote, unquote
 
 import pytest
 import yaml


### PR DESCRIPTION
Resolves #599 

TODO:
- [x] Support relevant formats for Open API 2
- [x] Other "in" locations - path, cookie, header
- [x] Docs & more tests
- [x] Serialize primitives