### PR TITLE
feat: GraphQL support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Schemathesis
 
 |Build| |Coverage| |Version| |Python versions| |Docs| |Chat| |License|
 
-Schemathesis is a tool for testing your web applications built with Open API / Swagger specifications.
+Schemathesis is a tool for testing your web applications built with Open API / Swagger or GraphQL specifications.
 
 It reads the application schema and generates test cases which will ensure that your application is compliant with its schema.
 
@@ -13,6 +13,7 @@ The application under test could be written in any language, the only thing you 
 
 - Swagger 2.0
 - Open API 3.0.x
+- GraphQL June 2018
 
 More API specifications will be added in the future.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Added
 ~~~~~
 
 - ``loaders.from_asgi`` supports making calls to ASGI-compliant application (For example: FastAPI). `#521`_
+- Support for GraphQL strategies.
 
 Fixed
 ~~~~~

--- a/docs/graphql.rst
+++ b/docs/graphql.rst
@@ -1,0 +1,43 @@
+.. _graphql:
+
+GraphQL
+=======
+
+Schemathesis provides basic capabilities for testing GraphQL-based applications.
+The current support is limited to creating Hypothesis strategies for tests and crafting appropriate network requests.
+
+**NOTE**: This area is in active development - more features will be added soon.
+
+Usage
+~~~~~
+
+At the moment there is no direct integration with pytest and in order to generate GraphQL queries you need to manually
+pass strategies to Hypothesis's ``given`` decorator.
+
+.. code:: python
+
+    import schemathesis
+
+    schema = schemathesis.graphql.from_url("https://bahnql.herokuapp.com/graphql")
+
+    @given(case=schema.query.as_strategy())
+    @settings(deadline=None)
+    def test(case):
+        response = case.call()
+        assert response.status_code < 500, response.content
+
+This test will load GraphQL schema from ``https://bahnql.herokuapp.com/graphql`` and will generate queries for it.
+In the test body, ``case`` instance provides only one method - ``call`` that will run a proper network request to the
+application under test.
+
+Limitations
+~~~~~~~~~~~
+
+Current GraphQL support does **NOT** include the following:
+
+- Direct pytest integration;
+- CLI integration;
+- Custom scalar types support (it will produce an error);
+- Mutations;
+- Filters for fields under test;
+- Hooks;

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to schemathesis's documentation!
    compatibility
    customization
    stateful
+   graphql
    targeted
    faq
    changelog

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,6 +34,14 @@ version = "0.7.12"
 
 [[package]]
 category = "dev"
+description = "A library for parsing ISO 8601 strings."
+name = "aniso8601"
+optional = false
+python-versions = "*"
+version = "8.0.0"
+
+[[package]]
+category = "dev"
 description = "apipkg: namespace control and lazy-import mechanism"
 name = "apipkg"
 optional = false
@@ -88,7 +96,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.4.5.2"
+version = "2020.6.20"
 
 [[package]]
 category = "main"
@@ -125,6 +133,15 @@ version = "4.5.4"
 
 [[package]]
 category = "dev"
+description = "A backport of the dataclasses module for Python 3.6"
+marker = "python_version < \"3.7\""
+name = "dataclasses"
+optional = false
+python-versions = "*"
+version = "0.6"
+
+[[package]]
+category = "dev"
 description = "Docutils -- Python Documentation Utilities"
 name = "docutils"
 optional = false
@@ -147,6 +164,24 @@ testing = ["pre-commit"]
 
 [[package]]
 category = "dev"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+name = "fastapi"
+optional = false
+python-versions = ">=3.6"
+version = "0.58.0"
+
+[package.dependencies]
+pydantic = ">=0.32.2,<2.0.0"
+starlette = "0.13.4"
+
+[package.extras]
+all = ["requests", "aiofiles", "jinja2", "python-multipart", "itsdangerous", "pyyaml", "graphene", "ujson", "orjson", "email-validator", "uvicorn", "async-exit-stack", "async-generator"]
+dev = ["pyjwt", "passlib", "autoflake", "flake8", "uvicorn", "graphene"]
+doc = ["mkdocs", "mkdocs-material", "markdown-include", "typer", "typer-cli", "pyyaml"]
+test = ["pytest (>=5.4.3)", "pytest-cov", "mypy", "black", "isort", "requests", "email-validator", "sqlalchemy", "peewee", "databases", "orjson", "async-exit-stack", "async-generator", "python-multipart", "aiofiles", "flask"]
+
+[[package]]
+category = "dev"
 description = "A simple framework for building complex web applications."
 name = "flask"
 optional = false
@@ -165,12 +200,60 @@ docs = ["sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-
 dotenv = ["python-dotenv"]
 
 [[package]]
+category = "dev"
+description = "GraphQL Framework for Python"
+name = "graphene"
+optional = false
+python-versions = "*"
+version = "3.0b3"
+
+[package.dependencies]
+aniso8601 = ">=8,<9"
+graphql-core = ">=3.1.0b1,<4"
+graphql-relay = ">=3.0,<4"
+
+[package.extras]
+dev = ["black (19.10b0)", "flake8 (>=3.7,<4)", "pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (2019.3)", "iso8601 (>=0.1,<2)"]
+test = ["pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (2019.3)", "iso8601 (>=0.1,<2)"]
+
+[[package]]
+category = "main"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+name = "graphql-core"
+optional = false
+python-versions = ">=3.6,<4"
+version = "3.1.1"
+
+[[package]]
+category = "dev"
+description = "Relay library for graphql-core-next"
+name = "graphql-relay"
+optional = false
+python-versions = ">=3.6,<4"
+version = "3.0.0"
+
+[package.dependencies]
+graphql-core = ">=3.0.0a0"
+
+[[package]]
+category = "dev"
+description = "GraphQL Server tools for powering your server"
+name = "graphql-server-core"
+optional = false
+python-versions = "*"
+version = "1.1.1"
+
+[package.dependencies]
+graphql-core = ">=2.1"
+promise = "*"
+
+[[package]]
 category = "main"
 description = "A library for property-based testing"
 name = "hypothesis"
 optional = false
 python-versions = ">=3.5.2"
-version = "5.16.1"
+version = "5.18.3"
 
 [package.dependencies]
 attrs = ">=19.2.0"
@@ -186,6 +269,18 @@ numpy = ["numpy (>=1.9.0)"]
 pandas = ["pandas (>=0.19)"]
 pytest = ["pytest (>=4.3)"]
 pytz = ["pytz (>=2014.1)"]
+
+[[package]]
+category = "main"
+description = "Hypothesis strategies for GraphQL schemas and queries"
+name = "hypothesis-graphql"
+optional = false
+python-versions = ">=3.6,<4.0"
+version = "0.3.1"
+
+[package.dependencies]
+graphql-core = ">=3.1.0,<4.0.0"
+hypothesis = ">=5.8.0,<6.0.0"
 
 [[package]]
 category = "main"
@@ -205,7 +300,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
+version = "2.10"
 
 [[package]]
 category = "dev"
@@ -234,7 +329,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.1"
+version = "1.7.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -351,12 +446,44 @@ version = ">=0.12"
 dev = ["pre-commit", "tox"]
 
 [[package]]
+category = "dev"
+description = "Promises/A+ implementation for Python"
+name = "promise"
+optional = false
+python-versions = "*"
+version = "2.3"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchmark", "mock"]
+
+[[package]]
 category = "main"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.1"
+version = "1.9.0"
+
+[[package]]
+category = "dev"
+description = "Data validation and settings management using python 3.6 type hinting"
+name = "pydantic"
+optional = false
+python-versions = ">=3.6"
+version = "1.5.1"
+
+[package.dependencies]
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = ">=0.6"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+typing_extensions = ["typing-extensions (>=3.7.2)"]
 
 [[package]]
 category = "dev"
@@ -430,8 +557,8 @@ category = "dev"
 description = "run tests in isolated forked subprocesses"
 name = "pytest-forked"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.1.3"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.2.0"
 
 [package.dependencies]
 pytest = ">=3.1.0"
@@ -500,7 +627,7 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.23.0"
+version = "2.24.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -640,6 +767,17 @@ lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
+category = "main"
+description = "The little ASGI library that shines."
+name = "starlette"
+optional = false
+python-versions = ">=3.6"
+version = "0.13.4"
+
+[package.extras]
+full = ["aiofiles", "graphene", "itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests", "ujson"]
+
+[[package]]
 category = "dev"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
@@ -666,7 +804,7 @@ description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 category = "main"
@@ -706,7 +844,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ebbd4d6c5112e414879979bf36863067d91f56e01fb0958e71c0d4fb235d5153"
+content-hash = "4073c6674501f065b37f6d26a3bb4395059444f660026f798afc06caf7c36d86"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -727,6 +865,10 @@ aiohttp = [
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+aniso8601 = [
+    {file = "aniso8601-8.0.0-py2.py3-none-any.whl", hash = "sha256:c033f63d028b9a58e3ab0c2c7d0532ab4bfa7452bfc788fbfe3ddabd327b181a"},
+    {file = "aniso8601-8.0.0.tar.gz", hash = "sha256:529dcb1f5f26ee0df6c0a1ee84b7b27197c3c50fc3a6321d66c544689237d072"},
 ]
 apipkg = [
     {file = "apipkg-1.5-py2.py3-none-any.whl", hash = "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"},
@@ -749,8 +891,8 @@ babel = [
     {file = "Babel-2.8.0.tar.gz", hash = "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38"},
 ]
 certifi = [
-    {file = "certifi-2020.4.5.2-py2.py3-none-any.whl", hash = "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"},
-    {file = "certifi-2020.4.5.2.tar.gz", hash = "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1"},
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -798,6 +940,10 @@ coverage = [
     {file = "coverage-4.5.4-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5"},
     {file = "coverage-4.5.4.tar.gz", hash = "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c"},
 ]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
@@ -806,21 +952,44 @@ execnet = [
     {file = "execnet-1.7.1-py2.py3-none-any.whl", hash = "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"},
     {file = "execnet-1.7.1.tar.gz", hash = "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50"},
 ]
+fastapi = [
+    {file = "fastapi-0.58.0-py3-none-any.whl", hash = "sha256:cdd953e806d5c6bee879178d4e6c7b2ebcee219ea252a39c1c98ad8c7b798235"},
+    {file = "fastapi-0.58.0.tar.gz", hash = "sha256:bfea20cc164885af99bad4bc680a99fe3b75d8d43b278ad51f1501d97cf8f762"},
+]
 flask = [
     {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},
     {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
 ]
+graphene = [
+    {file = "graphene-3.0b3-py2.py3-none-any.whl", hash = "sha256:d6a5846280bb5313622b1735cd52503c15c6016a90e7f7fa8d352700b74310ee"},
+    {file = "graphene-3.0b3.tar.gz", hash = "sha256:c7729a4cdd6641fd681f6cacf23ccae619d76c858ef94a834d175d0162576225"},
+]
+graphql-core = [
+    {file = "graphql-core-3.1.1.tar.gz", hash = "sha256:1fdc57d08f4492f06b21f3d487311e88fa8c33e0ac1e2d74ec79fb411ceba64a"},
+    {file = "graphql_core-3.1.1-py3-none-any.whl", hash = "sha256:25c2f537b430abc380de8765577938c78b5993584af627b7eb56b061b4ae234d"},
+]
+graphql-relay = [
+    {file = "graphql-relay-3.0.0.tar.gz", hash = "sha256:ad3f69a8b360c310c0c5611894f1e3fd5c6a5427b84f0f2cf5aee7a588bb5556"},
+    {file = "graphql_relay-3.0.0-py3-none-any.whl", hash = "sha256:b05ca0547557874f3bb1f34e4a6dce20bc60359fe6e73daaa63bb90df85f7ba9"},
+]
+graphql-server-core = [
+    {file = "graphql-server-core-1.1.1.tar.gz", hash = "sha256:e5f82add4b3d5580aa1f1e7d9f00e944ad3abe1b65eb337e611d6a77cc20f231"},
+]
 hypothesis = [
-    {file = "hypothesis-5.16.1-py3-none-any.whl", hash = "sha256:8e7ee0101086d95157f4886abd190cc582783b3310c803eb2387e505427e8cbe"},
-    {file = "hypothesis-5.16.1.tar.gz", hash = "sha256:dcd97367571657e9155d78ea0b6c3abf67acf4eaa6440e861213cd1beab02714"},
+    {file = "hypothesis-5.18.3-py3-none-any.whl", hash = "sha256:76144b48a54a197aac9e1aacbcdeca2e0e2753c838b3c7a22e0a6deb21fd01f5"},
+    {file = "hypothesis-5.18.3.tar.gz", hash = "sha256:b56c27733f896c80731302422c8c55dfd2e818059b3dca0f3717ddbae780dcd0"},
+]
+hypothesis-graphql = [
+    {file = "hypothesis-graphql-0.3.1.tar.gz", hash = "sha256:0403b735c9b7a4800f05fe23b0af5ba0e480acee465b747845f6ec222e2e081b"},
+    {file = "hypothesis_graphql-0.3.1-py3-none-any.whl", hash = "sha256:2d0a1ae799ed97a3fd366f9ee6fb47540858850c3e2d6f288117e85b746039d4"},
 ]
 hypothesis-jsonschema = [
     {file = "hypothesis-jsonschema-0.16.1.tar.gz", hash = "sha256:967704bee3e6d81cae350c0a514ea41e8d4645d4f76015386e62c0a323c16f4b"},
     {file = "hypothesis_jsonschema-0.16.1-py3-none-any.whl", hash = "sha256:66557e4377b2d23a2c389556ee22683780c8f95a38d4ac8e388d1be1fa890a20"},
 ]
 idna = [
-    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
-    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 idna-ssl = [
     {file = "idna-ssl-1.1.0.tar.gz", hash = "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"},
@@ -830,8 +999,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.1-py2.py3-none-any.whl", hash = "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"},
-    {file = "importlib_metadata-1.6.1.tar.gz", hash = "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545"},
+    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
+    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 itsdangerous = [
     {file = "itsdangerous-1.1.0-py2.py3-none-any.whl", hash = "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"},
@@ -914,9 +1083,31 @@ pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
+promise = [
+    {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
+]
 py = [
-    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
-    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
+    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+]
+pydantic = [
+    {file = "pydantic-1.5.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2a6904e9f18dea58f76f16b95cba6a2f20b72d787abd84ecd67ebc526e61dce6"},
+    {file = "pydantic-1.5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:da8099fca5ee339d5572cfa8af12cf0856ae993406f0b1eb9bb38c8a660e7416"},
+    {file = "pydantic-1.5.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:68dece67bff2b3a5cc188258e46b49f676a722304f1c6148ae08e9291e284d98"},
+    {file = "pydantic-1.5.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ab863853cb502480b118187d670f753be65ec144e1654924bec33d63bc8b3ce2"},
+    {file = "pydantic-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:2007eb062ed0e57875ce8ead12760a6e44bf5836e6a1a7ea81d71eeecf3ede0f"},
+    {file = "pydantic-1.5.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:20a15a303ce1e4d831b4e79c17a4a29cb6740b12524f5bba3ea363bff65732bc"},
+    {file = "pydantic-1.5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:473101121b1bd454c8effc9fe66d54812fdc128184d9015c5aaa0d4e58a6d338"},
+    {file = "pydantic-1.5.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:9be755919258d5d168aeffbe913ed6e8bd562e018df7724b68cabdee3371e331"},
+    {file = "pydantic-1.5.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:b96ce81c4b5ca62ab81181212edfd057beaa41411cd9700fbcb48a6ba6564b4e"},
+    {file = "pydantic-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:93b9f265329d9827f39f0fca68f5d72cc8321881cdc519a1304fa73b9f8a75bd"},
+    {file = "pydantic-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e2c753d355126ddd1eefeb167fa61c7037ecd30b98e7ebecdc0d1da463b4ea09"},
+    {file = "pydantic-1.5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8433dbb87246c0f562af75d00fa80155b74e4f6924b0db6a2078a3cd2f11c6c4"},
+    {file = "pydantic-1.5.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0a1cdf24e567d42dc762d3fed399bd211a13db2e8462af9dfa93b34c41648efb"},
+    {file = "pydantic-1.5.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:8be325fc9da897029ee48d1b5e40df817d97fe969f3ac3fd2434ba7e198c55d5"},
+    {file = "pydantic-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:3714a4056f5bdbecf3a41e0706ec9b228c9513eee2ad884dc2c568c4dfa540e9"},
+    {file = "pydantic-1.5.1-py36.py37.py38-none-any.whl", hash = "sha256:70f27d2f0268f490fe3de0a9b6fca7b7492b8fd6623f9fecd25b221ebee385e3"},
+    {file = "pydantic-1.5.1.tar.gz", hash = "sha256:f0018613c7a0d19df3240c2a913849786f21b6539b9f23d85ce4067489dfacfa"},
 ]
 pygments = [
     {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
@@ -938,8 +1129,8 @@ pytest-asyncio = [
     {file = "pytest_asyncio-0.11.0-py3-none-any.whl", hash = "sha256:6096d101a1ae350d971df05e25f4a8b4d3cd13ffb1b32e42d902ac49670d2bfa"},
 ]
 pytest-forked = [
-    {file = "pytest-forked-1.1.3.tar.gz", hash = "sha256:1805699ed9c9e60cb7a8179b8d4fa2b8898098e82d229b0825d8095f0f261100"},
-    {file = "pytest_forked-1.1.3-py2.py3-none-any.whl", hash = "sha256:1ae25dba8ee2e56fb47311c9638f9e58552691da87e82d25b0ce0e4bf52b7d87"},
+    {file = "pytest-forked-1.2.0.tar.gz", hash = "sha256:65f96334863d9cbe53d21f73e8febc4dd61b8d1fdcac7b487d9af07a5d02a938"},
+    {file = "pytest_forked-1.2.0-py2.py3-none-any.whl", hash = "sha256:42a438336731465c5bd76ab38e1645647ac55914a08b507efbabe8783a08aa6c"},
 ]
 pytest-mock = [
     {file = "pytest-mock-1.13.0.tar.gz", hash = "sha256:e24a911ec96773022ebcc7030059b57cd3480b56d4f5d19b7c370ec635e6aed5"},
@@ -971,8 +1162,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 requests = [
-    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
-    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -1014,6 +1205,10 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
     {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
 ]
+starlette = [
+    {file = "starlette-0.13.4-py3-none-any.whl", hash = "sha256:0fb4b38d22945b46acb880fedee7ee143fd6c0542992501be8c45c0ed737dd1a"},
+    {file = "starlette-0.13.4.tar.gz", hash = "sha256:04fe51d86fd9a594d9b71356ed322ccde5c9b448fc716ac74155e5821a922f8d"},
+]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
     {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
@@ -1024,8 +1219,8 @@ urllib3 = [
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.2.4-py2.py3-none-any.whl", hash = "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f"},
-    {file = "wcwidth-0.2.4.tar.gz", hash = "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"},
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "schemathesis"
 version = "1.9.1"
-description = "Hypothesis strategies for Open API / Swagger schemas"
-keywords = ["pytest", "hypothesis", "openapi", "swagger", "testing"]
+description = "Hypothesis strategies for Open API / Swagger and GraphQL schemas"
+keywords = ["pytest", "hypothesis", "openapi", "swagger", "graphql", "testing"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -28,6 +28,7 @@ python = "^3.6"
 attrs = "^19.1"
 hypothesis = ">=5.15,<6.0"
 hypothesis_jsonschema = ">=0.16.0,<1.0"
+hypothesis_graphql = ">=0.3"
 jsonschema = "^3.0.0"
 pytest = ">4.6.4"
 pyyaml = "^5.1"
@@ -43,6 +44,8 @@ starlette = "^0.13.2"
 coverage = "^4.5"
 pytest = ">4.6.4"
 aiohttp = "^3.6"
+graphene = "^3.0b3"
+graphql-server-core = "https://github.com/graphql-python/graphql-server-core.git@8e2f147a2c23ec7275fe1924dc0c190370ffd256"
 pytest-mock = "^1.11.0"
 pytest-asyncio = "^0.11.0"
 pytest-xdist = "^1.30"
@@ -68,7 +71,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "fastapi", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "fastapi", "flask", "graphene", "graphql", "graphql_server", "hypothesis", "hypothesis_graphql", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/schemathesis/__init__.py
+++ b/src/schemathesis/__init__.py
@@ -4,5 +4,6 @@ from .cli import register_check
 from .constants import __version__
 from .loaders import from_dict, from_file, from_path, from_pytest_fixture, from_uri, from_wsgi
 from .models import Case
+from .specs import graphql
 
 init_default_strategies()

--- a/src/schemathesis/extra/_aiohttp.py
+++ b/src/schemathesis/extra/_aiohttp.py
@@ -1,10 +1,9 @@
 import asyncio
-import threading
-from time import sleep
 from typing import Optional
 
 from aiohttp import web  # pylint: disable=import-error
-from aiohttp.test_utils import unused_port  # pylint: disable=import-error
+
+from . import _server
 
 
 def _run_server(app: web.Application, port: int) -> None:
@@ -25,10 +24,4 @@ def _run_server(app: web.Application, port: int) -> None:
 
 def run_server(app: web.Application, port: Optional[int] = None, timeout: float = 0.05) -> int:
     """Start a thread with the given aiohttp application."""
-    if port is None:
-        port = unused_port()
-    server_thread = threading.Thread(target=_run_server, args=(app, port))
-    server_thread.daemon = True
-    server_thread.start()
-    sleep(timeout)
-    return port
+    return _server.run(_run_server, app=app, port=port, timeout=timeout)

--- a/src/schemathesis/extra/_flask.py
+++ b/src/schemathesis/extra/_flask.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from flask import Flask
+
+from . import _server
+
+
+def run_server(app: Flask, port: Optional[int] = None, timeout: float = 0.05) -> int:
+    """Start a thread with the given aiohttp application."""
+    return _server.run(app.run, port=port, timeout=timeout)

--- a/src/schemathesis/extra/_server.py
+++ b/src/schemathesis/extra/_server.py
@@ -1,0 +1,16 @@
+import threading
+from time import sleep
+from typing import Any, Callable, Optional
+
+from aiohttp.test_utils import unused_port
+
+
+def run(target: Callable, port: Optional[int] = None, timeout: float = 0.05, **kwargs: Any) -> int:
+    """Start a thread with the given aiohttp application."""
+    if port is None:
+        port = unused_port()
+    server_thread = threading.Thread(target=target, kwargs={"port": port, **kwargs})
+    server_thread.daemon = True
+    server_thread.start()
+    sleep(timeout)
+    return port

--- a/src/schemathesis/specs/graphql/__init__.py
+++ b/src/schemathesis/specs/graphql/__init__.py
@@ -1,0 +1,1 @@
+from .loaders import from_url

--- a/src/schemathesis/specs/graphql/loaders.py
+++ b/src/schemathesis/specs/graphql/loaders.py
@@ -1,0 +1,94 @@
+import requests
+
+from .schemas import GraphQLSchema
+
+INTROSPECTION_QUERY = """
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+fragment FullType on __Type {
+  kind
+  name
+  fields(includeDeprecated: true) {
+    name
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  type { ...TypeRef }
+  defaultValue
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"""
+
+
+def from_url(url: str) -> GraphQLSchema:
+    response = requests.post(url, json={"query": INTROSPECTION_QUERY})
+    raw_schema = response.json()
+    return GraphQLSchema(raw_schema["data"], location=url)

--- a/src/schemathesis/specs/graphql/schemas.py
+++ b/src/schemathesis/specs/graphql/schemas.py
@@ -1,0 +1,44 @@
+from functools import partial
+
+import attr
+import graphql
+import requests
+from hypothesis import strategies as st
+from hypothesis_graphql import strategies as gql_st
+
+from ...schemas import BaseSchema
+
+
+@attr.s()  # pragma: no mutate
+class GraphQLCase:
+    path: str = attr.ib()  # pragma: no mutate
+    data: str = attr.ib()  # pragma: no mutate
+
+    def call(self) -> requests.Response:
+        return requests.post(self.path, json={"query": self.data})
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class GraphQLQuery:
+    path: str = attr.ib()  # pragma: no mutate
+    schema: graphql.GraphQLSchema = attr.ib()  # pragma: no mutate
+
+    def as_strategy(self) -> st.SearchStrategy[GraphQLCase]:
+        constructor = partial(GraphQLCase, path=self.path)
+        return st.builds(constructor, data=gql_st.query(self.schema))
+
+
+@attr.s()  # pragma: no mutate
+class GraphQLSchema(BaseSchema):
+    schema: graphql.GraphQLSchema = attr.ib(init=False)  # pragma: no mutate
+
+    def __attrs_post_init__(self) -> None:
+        self.schema = graphql.build_client_schema(self.raw_schema)
+
+    @property  # pragma: no mutate
+    def verbose_name(self) -> str:
+        return "GraphQL"
+
+    @property
+    def query(self) -> GraphQLQuery:
+        return GraphQLQuery(path=self.location or "", schema=self.schema)

--- a/test/apps/__init__.py
+++ b/test/apps/__init__.py
@@ -7,18 +7,19 @@ from aiohttp import web
 from schemathesis.cli import CSVOption
 
 try:
-    from . import _aiohttp, _flask
+    from . import _aiohttp, _flask, _graphql
     from .utils import Endpoint
 except ImportError:
     import _aiohttp
     import _flask
+    import _graphql
     from utils import Endpoint
 
 
 @click.command()
 @click.argument("port", type=int)
 @click.option("--endpoints", type=CSVOption(Endpoint))
-@click.option("--framework", type=click.Choice(["aiohttp", "flask"]), default="aiohttp")
+@click.option("--framework", type=click.Choice(["aiohttp", "flask", "graphql"]), default="aiohttp")
 def run_app(port: int, endpoints: List[Endpoint], framework: str) -> None:
     if endpoints is not None:
         prepared_endpoints = tuple(endpoint.name for endpoint in endpoints)
@@ -29,6 +30,9 @@ def run_app(port: int, endpoints: List[Endpoint], framework: str) -> None:
         web.run_app(app, port=port)
     elif framework == "flask":
         app = _flask.create_app(prepared_endpoints)
+        app.run(port=port)
+    elif framework == "graphql":
+        app = _graphql.create_app()
         app.run(port=port)
 
 

--- a/test/apps/_graphql/__init__.py
+++ b/test/apps/_graphql/__init__.py
@@ -1,0 +1,12 @@
+from flask import Flask
+from graphql_server.flask import GraphQLView
+
+from .schema import schema
+
+
+def create_app(path="/graphql", **kwargs):
+    app = Flask("test_app")
+    app.add_url_rule(
+        path, view_func=GraphQLView.as_view("graphql", schema=schema.graphql_schema, graphiql=True, **kwargs)
+    )
+    return app

--- a/test/apps/_graphql/app.py
+++ b/test/apps/_graphql/app.py
@@ -1,0 +1,3 @@
+from . import create_app
+
+app = create_app()

--- a/test/apps/_graphql/schema.py
+++ b/test/apps/_graphql/schema.py
@@ -1,0 +1,18 @@
+import graphene
+
+
+class Patron(graphene.ObjectType):
+    id = graphene.ID()
+    name = graphene.String()
+    age = graphene.Int()
+
+
+class Query(graphene.ObjectType):
+
+    patron = graphene.Field(Patron)
+
+    def resolve_patron(root, info):
+        return Patron(id=1, name="Syrus", age=27)
+
+
+schema = graphene.Schema(query=Query)

--- a/test/specs/graphql/test_basic.py
+++ b/test/specs/graphql/test_basic.py
@@ -1,0 +1,56 @@
+import pytest
+from hypothesis import given, settings
+
+import schemathesis
+
+
+@pytest.fixture()
+def graphql_schema(graphql_endpoint):
+    return schemathesis.graphql.from_url(graphql_endpoint)
+
+
+def test_raw_schema(graphql_schema):
+    assert graphql_schema.raw_schema["__schema"]["types"][1] == {
+        "kind": "OBJECT",
+        "name": "Patron",
+        "fields": [
+            {
+                "name": "id",
+                "args": [],
+                "type": {"kind": "SCALAR", "name": "ID", "ofType": None},
+                "isDeprecated": False,
+                "deprecationReason": None,
+            },
+            {
+                "name": "name",
+                "args": [],
+                "type": {"kind": "SCALAR", "name": "String", "ofType": None},
+                "isDeprecated": False,
+                "deprecationReason": None,
+            },
+            {
+                "name": "age",
+                "args": [],
+                "type": {"kind": "SCALAR", "name": "Int", "ofType": None},
+                "isDeprecated": False,
+                "deprecationReason": None,
+            },
+        ],
+        "inputFields": None,
+        "interfaces": [],
+        "enumValues": None,
+        "possibleTypes": None,
+    }
+
+
+@pytest.mark.hypothesis_nested
+def test_query_strategy(graphql_schema):
+    strategy = graphql_schema.query.as_strategy()
+
+    @given(case=strategy)
+    @settings(max_examples=10)
+    def test(case):
+        response = case.call()
+        assert response.status_code < 500
+
+    test()

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ deps =
   coverage
   pytest-asyncio
   pytest-mock
+  graphene==3.0b3
+  git+https://github.com/graphql-python/graphql-server-core.git@8e2f147a2c23ec7275fe1924dc0c190370ffd256#egg=graphql-server-core
 commands =
   coverage run --source=schemathesis -m pytest {posargs:} test
 
@@ -26,6 +28,8 @@ deps =
   pytest<5.4
   pytest-asyncio<0.11.0
   pytest-mock
+  graphene==3.0b3
+  git+https://github.com/graphql-python/graphql-server-core.git@8e2f147a2c23ec7275fe1924dc0c190370ffd256#egg=graphql-server-core
 
 [testenv:pylint]
 deps = pylint


### PR DESCRIPTION
WIP support for GraphQL. At the moment it is possible to create a strategy and use it in a test:

```python
schema = schemathesis.graphql.from_url("https://bahnql.herokuapp.com/graphql")

@given(case=schema.query.as_strategy()) 
@settings(deadline=None) 
def test(case): 
    response = case.call() 
    assert response.status_code < 500, response.content
```

Execution of the test above sometimes triggers `{"errors":[{"message":"Betriebsstellen: Failed to parse JSON","locations":[{"line":3,"column":5}],"path":["search","operationLocations"]}],"data":null}'` on a valid query :)

Roadmap:

- [ ] Design the API
- [ ] Integrate with pytest
- [ ] Integrate with CLI
- [ ] More complex test app to test nested objects, etc
- [ ] Mutations support
- [ ] Filters, hooks (?)
- [ ] Fix dependencies (there should be beta versions of packages)
- [ ] Custom scalar types support? Or at least handle gracefully - maybe exclude such a field from a query if possible

The current implementation on the `hypothesis-graphql` side is extremely slow :( I need to find ways to speed it up. 

Also, I am not sure that it is feasible to create a more generic interface in `BaseSchema` - maybe it will be easier to handle GraphQL things separately rather than trying to embed them into existing code - many things are not applicable here (e.g. tags, methods, endpoints, all `Case` structure, etc)

Comments, questions & suggestions are welcome