### PR TITLE
feat: support for multiple examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,6 +296,8 @@ Explicit examples
 ~~~~~~~~~~~~~~~~~
 
 If the schema contains parameters examples, then they will be additionally included in the generated cases.
+Schemathesis supports the use of both OpenAPI ``example`` and ``examples`` (more information available in the `OpenAPI documentation <https://swagger.io/docs/specification/adding-examples/>`_).
+Note that ``examples`` were added in OpenAPI 3, but Schemathesis supports this feature for OpenAPI 2 using ``x-examples``.
 
 .. code:: yaml
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 Added
 ~~~~~
 
+- support for multiple examples with OpenAPI ``examples``. `#589`_
 - ``--verbosity`` CLI option to minimize the error output. `#598`_
 
 `1.8.0`_ - 2020-06-15
@@ -1119,6 +1120,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#589: https://github.com/kiwicom/schemathesis/issues/589
 .. _#614: https://github.com/kiwicom/schemathesis/issues/614
 .. _#612: https://github.com/kiwicom/schemathesis/issues/612
 .. _#600: https://github.com/kiwicom/schemathesis/issues/600

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -285,6 +285,10 @@ class Endpoint:
 
         return get_case_strategy(self, hooks)
 
+    def get_strategies_from_examples(self) -> List[SearchStrategy[Case]]:
+        """Get examples from endpoint."""
+        return self.schema.get_strategies_from_examples(self)
+
     def get_stateful_tests(self, response: GenericResponse, stateful: Optional[str]) -> Sequence["StatefulTest"]:
         return self.schema.get_stateful_tests(response, self, stateful)
 

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -12,12 +12,13 @@ from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Seq
 
 import attr
 import hypothesis
+from hypothesis.strategies import SearchStrategy
 from requests.structures import CaseInsensitiveDict
 
 from ._hypothesis import make_test_or_exception
 from .exceptions import InvalidSchema
 from .hooks import HookContext, HookDispatcher, HookLocation, HookScope, dispatch, warn_deprecated_hook
-from .models import Endpoint
+from .models import Case, Endpoint
 from .stateful import StatefulTest
 from .types import Filter, GenericTest, Hook, NotSet
 from .utils import NOT_SET, GenericResponse, deprecated
@@ -59,6 +60,10 @@ class BaseSchema(Mapping):
         return len(list(self.get_all_endpoints()))
 
     def get_all_endpoints(self) -> Generator[Endpoint, None, None]:
+        raise NotImplementedError
+
+    def get_strategies_from_examples(self, endpoint: Endpoint) -> List[SearchStrategy[Case]]:
+        """Get examples from endpoint."""
         raise NotImplementedError
 
     def get_stateful_tests(

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -1,0 +1,93 @@
+from typing import Any, Dict, List, Optional
+
+from hypothesis.strategies import SearchStrategy
+
+from ..._hypothesis import LOCATION_TO_CONTAINER, PARAMETERS, _get_case_strategy, prepare_strategy
+from ...models import Case, Endpoint
+
+
+def get_param_examples(endpoint_def: Dict[str, Any], examples_field: str) -> List[Dict[str, Any]]:
+    return [
+        {
+            "type": LOCATION_TO_CONTAINER.get(param["in"]),
+            "name": param["name"],
+            "examples": [example["value"] for example in param[examples_field].values()],
+        }
+        for param in endpoint_def.get("parameters", [])
+        if examples_field in param
+    ]
+
+
+def get_request_body_examples(endpoint_def: Dict[str, Any], examples_field: str) -> Dict[str, Any]:
+    request_bodies_items = endpoint_def.get("requestBody", {}).get("content", {}).items()
+    if not request_bodies_items:
+        return {}
+    # first element in tuple in media type, second element is dict
+    media_type, schema = next(iter(request_bodies_items))
+    param_type = "body" if media_type != "multipart/form-data" else "form_data"
+    return {"type": param_type, "examples": [example["value"] for example in schema.get(examples_field, {}).values()]}
+
+
+def get_static_params_from_example(endpoint: Endpoint) -> Dict[str, Any]:
+    static_parameters = {}
+    for name in PARAMETERS:
+        parameter = getattr(endpoint, name)
+        if parameter is not None and "example" in parameter:
+            static_parameters[name] = parameter["example"]
+    return static_parameters
+
+
+def get_static_params_from_examples(endpoint: Endpoint, examples_field: str) -> List[Dict[str, Any]]:
+    endpoint_def = endpoint.definition.resolved
+    return merge_examples(
+        get_param_examples(endpoint_def, examples_field), get_request_body_examples(endpoint_def, examples_field)
+    )
+
+
+def get_strategies_from_examples(endpoint: Endpoint, examples_field: str = "examples") -> List[SearchStrategy[Case]]:
+    strategies = [
+        get_strategy(endpoint, static_params)
+        for static_params in get_static_params_from_examples(endpoint, examples_field)
+    ]
+    strategy = get_strategy(endpoint, get_static_params_from_example(endpoint))
+    if strategy is not None:
+        strategies.append(strategy)
+    return strategies
+
+
+def get_strategy(endpoint: Endpoint, static_parameters: Dict[str, Any]) -> Optional[SearchStrategy[Case]]:
+    if static_parameters:
+        strategies = {
+            parameter: prepare_strategy(
+                parameter, getattr(endpoint, parameter), endpoint.get_hypothesis_conversions(parameter)
+            )
+            for parameter in PARAMETERS - set(static_parameters)
+            if getattr(endpoint, parameter) is not None
+        }
+        return _get_case_strategy(endpoint, static_parameters, strategies)
+    return None
+
+
+def merge_examples(
+    parameter_examples: List[Dict[str, Any]], request_body_examples: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """Create list of static parameter objects from parameter and request body examples."""
+    static_param_list = []
+    for idx in range(num_examples(parameter_examples, request_body_examples)):
+        static_params: Dict[str, Any] = {}
+        for param in parameter_examples:
+            if param["type"] not in static_params:
+                static_params[param["type"]] = {}
+            static_params[param["type"]][param["name"]] = param["examples"][min(idx, len(param["examples"]) - 1)]
+        if "examples" in request_body_examples:
+            static_params[request_body_examples["type"]] = request_body_examples["examples"][
+                min(idx, len(request_body_examples["examples"]) - 1)
+            ]
+        static_param_list.append(static_params)
+    return static_param_list
+
+
+def num_examples(parameter_examples: List[Dict[str, Any]], request_body_examples: Dict[str, Any]) -> int:
+    max_param_examples = max(len(param["examples"]) for param in parameter_examples) if parameter_examples else 0
+    num_request_body_examples = len(request_body_examples["examples"]) if "examples" in request_body_examples else 0
+    return max(max_param_examples, num_request_body_examples)

--- a/src/schemathesis/specs/openapi/links.py
+++ b/src/schemathesis/specs/openapi/links.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, NoReturn, Optional, Sequence, Tuple
 
 import attr
 
+from ..._hypothesis import LOCATION_TO_CONTAINER
 from ...models import Case, Endpoint
 from ...stateful import ParsedData, StatefulTest
 from ...utils import NOT_SET, GenericResponse
@@ -160,14 +161,6 @@ class Link(StatefulTest):
 
     def _unknown_parameter(self, name: str) -> NoReturn:
         raise ValueError(f"Parameter `{name}` is not defined in endpoint {self.endpoint.method} {self.endpoint.path}")
-
-
-LOCATION_TO_CONTAINER = {
-    "path": "path_parameters",
-    "query": "query",
-    "header": "headers",
-    "cookie": "cookies",
-}
 
 
 def get_links(response: GenericResponse, endpoint: Endpoint, field: str) -> Sequence[Link]:

--- a/test/specs/openapi/test_examples.py
+++ b/test/specs/openapi/test_examples.py
@@ -1,0 +1,160 @@
+import pathlib
+from test.utils import HERE
+
+import pytest
+import yaml
+from _pytest.main import ExitCode
+
+import schemathesis
+from schemathesis.models import Endpoint, EndpointDefinition
+from schemathesis.specs.openapi import examples
+from schemathesis.specs.openapi.schemas import BaseOpenAPISchema
+
+
+@pytest.fixture(scope="module")
+def schema_with_examples() -> BaseOpenAPISchema:
+    return schemathesis.from_dict(
+        {
+            "openapi": "3.0.2",
+            "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+            "servers": [{"url": "http://127.0.0.1:8081/{basePath}", "variables": {"basePath": {"default": "api"}}}],
+            "paths": {
+                "/success": {
+                    "post": {
+                        "parameters": [
+                            {
+                                "name": "anyKey",
+                                "in": "header",
+                                "required": True,
+                                "schema": {"type": "string"},
+                                "examples": {"header1": {"value": "header1"}, "header2": {"value": "header2"}},
+                            },
+                            {
+                                "name": "id",
+                                "in": "query",
+                                "required": True,
+                                "schema": {"type": "string"},
+                                "examples": {"query1": {"value": "query1"}},
+                            },
+                            {"name": "idWithoutExamples", "in": "query", "schema": {"type": "string"}},
+                        ],
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "object", "properties": {"foo": {"type": "string"}}},
+                                    "examples": {
+                                        "body1": {"value": {"foo": "string1"}},
+                                        "body2": {"value": {"foo": "string2"}},
+                                        "body3": {"value": {"foo": "string3"}},
+                                    },
+                                }
+                            }
+                        },
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        }
+    )
+
+
+@pytest.fixture()
+def endpoint(schema_with_examples) -> Endpoint:
+    """Returns first (and only) endpoint from schema_with_examples."""
+    return next(schema_with_examples.get_all_endpoints())
+
+
+def test_get_param_examples(endpoint):
+    param_examples = examples.get_param_examples(endpoint.definition.raw, "examples")
+
+    # length equals the number of parameters with examples
+    assert len(param_examples) == 2
+
+    assert param_examples[0]["type"] == "headers"
+    assert param_examples[0]["name"] == "anyKey"
+    assert len(param_examples[0]["examples"]) == 2
+
+    assert param_examples[1]["type"] == "query"
+    assert param_examples[1]["name"] == "id"
+    assert len(param_examples[1]["examples"]) == 1
+
+
+def test_get_request_body_examples(endpoint):
+    request_body_examples = examples.get_request_body_examples(endpoint.definition.raw, "examples")
+
+    assert request_body_examples["type"] == "body"
+    assert len(request_body_examples["examples"]) == 3
+
+
+def test_get_static_params_from_examples(endpoint):
+    static_params_list = examples.get_static_params_from_examples(endpoint, "examples")
+
+    assert len(static_params_list) == 3
+
+    # ensure that each request body example is included at least once
+    assert all(
+        [
+            any("string1" == static_params["body"]["foo"] for static_params in static_params_list),
+            any("string2" == static_params["body"]["foo"] for static_params in static_params_list),
+            any("string3" == static_params["body"]["foo"] for static_params in static_params_list),
+        ]
+    )
+    # ensure that each header parameter example is included at least once
+    assert all(
+        [
+            any("header1" in static_params["headers"]["anyKey"] for static_params in static_params_list),
+            any("header2" in static_params["headers"]["anyKey"] for static_params in static_params_list),
+        ]
+    )
+    # ensure that each query parameter example is included at least once
+    assert any("query1" in static_params["query"]["id"] for static_params in static_params_list)
+
+
+def test_get_strategies_from_examples(endpoint):
+    strategies = examples.get_strategies_from_examples(endpoint, "examples")
+
+    assert len(strategies) == 3
+    assert all(strategy is not None for strategy in strategies)
+
+
+def test_merge_examples_no_body_examples():
+    parameter_examples = [
+        {"type": "query", "name": "queryParam", "examples": ["example1", "example2", "example3"]},
+        {"type": "headers", "name": "headerParam", "examples": ["example1"]},
+        {"type": "path_parameters", "name": "pathParam", "examples": ["example1", "example2"]},
+    ]
+    request_body_examples = {}
+    result = examples.merge_examples(parameter_examples, request_body_examples)
+
+    assert len(result) == 3
+    assert all("query" in static_params and "queryParam" in static_params["query"] for static_params in result)
+    assert all("headers" in static_params and "headerParam" in static_params["headers"] for static_params in result)
+    assert all(
+        "path_parameters" in static_params and "pathParam" in static_params["path_parameters"]
+        for static_params in result
+    )
+
+
+def test_merge_examples_with_body_examples():
+    parameter_examples = []
+    request_body_examples = {
+        "type": "body",
+        "examples": [{"foo": "example1"}, {"foo": "example2"}, {"foo": "example3"}],
+    }
+    result = examples.merge_examples(parameter_examples, request_body_examples)
+
+    assert len(result) == 3
+    assert all("body" in static_params and "foo" in static_params["body"] for static_params in result)
+
+
+def test_examples_from_cli(app, testdir, cli, base_url, schema_with_examples):
+    schema = schema_with_examples.raw_schema
+    app["config"].update({"schema_data": schema})
+    schema_file = testdir.makefile(".yaml", schema=yaml.dump(schema))
+    result = cli.run(str(schema_file), f"--base-url={base_url}", "--hypothesis-phases=explicit",)
+
+    assert result.exit_code == ExitCode.OK, result.stdout
+    # The request body has the 3 examples defined. Because 3 is the most examples defined
+    # for any parameter, we expect to generate 3 requests.
+    not_a_server_line = next(filter(lambda line: "not_a_server_error" in line, result.stdout.split("\n")))
+    assert "3 / 3 passed" in not_a_server_line

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2,7 +2,8 @@ import pytest
 from hypothesis import given
 
 import schemathesis
-from schemathesis._hypothesis import get_example
+from schemathesis.models import Endpoint
+from schemathesis.specs.openapi.examples import get_strategies_from_examples
 
 
 @pytest.fixture(scope="module")
@@ -29,7 +30,8 @@ def schema():
 
 @pytest.mark.hypothesis_nested
 def test_examples_validity(schema, base_url):
-    strategy = get_example(schema.endpoints["/api/success"]["get"])
+    endpoint = next(schema.get_all_endpoints())
+    strategy = get_strategies_from_examples(endpoint, "examples")[0]
 
     @given(case=strategy)
     def test(case):

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -5,7 +5,7 @@ from hypothesis import HealthCheck, given, settings, strategies
 
 import schemathesis
 from schemathesis import Case, register_string_format
-from schemathesis._hypothesis import PARAMETERS, get_case_strategy, get_example, is_valid_query
+from schemathesis._hypothesis import PARAMETERS, get_case_strategy, is_valid_query
 from schemathesis.exceptions import InvalidSchema
 from schemathesis.models import Endpoint, EndpointDefinition
 
@@ -30,7 +30,9 @@ def test_get_examples(name, swagger_20):
             }
         },
     )
-    assert get_example(endpoint).example() == Case(endpoint, **{name: example})
+    strategies = endpoint.get_strategies_from_examples()
+    assert len(strategies) == 1
+    assert strategies[0].example() == Case(endpoint, **{name: example})
 
 
 @pytest.mark.filterwarnings("ignore:.*method is good for exploring strategies.*")
@@ -48,7 +50,9 @@ def test_no_body_in_get(swagger_20):
             "example": {"name": "John"},
         },
     )
-    assert get_example(endpoint).example().body is None
+    strategies = endpoint.get_strategies_from_examples()
+    assert len(strategies) == 1
+    assert strategies[0].example().body is None
 
 
 def test_invalid_body_in_get(swagger_20):


### PR DESCRIPTION
Implements #589

Updates:
- add specs/openapi/examples to hold the logic for retrieving examples from endpoints
- add support for OpenAPI examples

Tests:
- add unit tests for retrieving examples from "examples"
- add tests to make sure the static_parameter objects are created correctly

Note:
- Implementation allows the "example" and "examples" keywords to be used at the same time. We get all examples from "examples", and if "example" is used also, we create one more strategy using the "example" values.