### PR TITLE
fix: Show exception information for test runs on invalid schemas with `--validate-schema=false` command-line option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,10 +12,17 @@ Added
 - support for multiple examples with OpenAPI ``examples``. `#589`_
 - ``--verbosity`` CLI option to minimize the error output. `#598`_
 
+Changed
+~~~~~~~
+
+- Tests with invalid schemas marked as errors, instead of failures. `#622`_
+
 Fixed
 ~~~~~
 
 - Crash during generation of loosely-defined headers. `#621`_
+- Show exception information for test runs on invalid schemas with ``--validate-schema=false`` command-line option.
+  Before the output sections for invalid endpoints were empty. `#622`_
 
 `1.8.0`_ - 2020-06-15
 ---------------------
@@ -23,7 +30,7 @@ Fixed
 Fixed
 ~~~~~
 
-- Tests with invalid schemas are marked as failed when ``hypothesis-jsonschema>=0.16`` is installed. `#614`_
+- Tests with invalid schemas are marked as failed instead of passed when ``hypothesis-jsonschema>=0.16`` is installed. `#614`_
 - ``KeyError`` during creating endpoint strategy if it contains a reference. `#612`_
 
 Changed

--- a/src/schemathesis/exceptions.py
+++ b/src/schemathesis/exceptions.py
@@ -7,45 +7,50 @@ from jsonschema import ValidationError
 
 from .utils import WSGIResponse
 
-CACHE: Dict[Union[str, int], Type[AssertionError]] = {}
+
+class CheckFailed(AssertionError):
+    """Custom error type to distinguish from arbitrary AssertionError that may happen in the dependent libraries."""
 
 
-def get_exception(name: str) -> Type[AssertionError]:
+CACHE: Dict[Union[str, int], Type[CheckFailed]] = {}
+
+
+def get_exception(name: str) -> Type[CheckFailed]:
     """Create a new exception class with provided name or fetch one from cache."""
     if name in CACHE:
         exception_class = CACHE[name]
     else:
-        exception_class = type(name, (AssertionError,), {})
+        exception_class = type(name, (CheckFailed,), {})
         CACHE[name] = exception_class
     return exception_class
 
 
-def _get_hashed_exception(prefix: str, message: str) -> Type[AssertionError]:
+def _get_hashed_exception(prefix: str, message: str) -> Type[CheckFailed]:
     """Give different exceptions for different error messages."""
     messages_digest = sha1(message.encode("utf-8")).hexdigest()
     name = f"{prefix}{messages_digest}"
     return get_exception(name)
 
 
-def get_grouped_exception(*exceptions: AssertionError) -> Type[AssertionError]:
+def get_grouped_exception(*exceptions: AssertionError) -> Type[CheckFailed]:
     messages = [exception.args[0] for exception in exceptions]
     message = "".join(messages)
     return _get_hashed_exception("GroupedException", message)
 
 
-def get_status_code_error(status_code: int) -> Type[AssertionError]:
+def get_status_code_error(status_code: int) -> Type[CheckFailed]:
     """Return new exception for an unexpected status code."""
     name = f"StatusCodeError{status_code}"
     return get_exception(name)
 
 
-def get_response_type_error(expected: str, received: str) -> Type[AssertionError]:
+def get_response_type_error(expected: str, received: str) -> Type[CheckFailed]:
     """Return new exception for an unexpected response type."""
     name = f"SchemaValidationError{expected}_{received}"
     return get_exception(name)
 
 
-def get_schema_validation_error(exception: ValidationError) -> Type[AssertionError]:
+def get_schema_validation_error(exception: ValidationError) -> Type[CheckFailed]:
     """Return new exception for schema validation error."""
     return _get_hashed_exception("SchemaValidationError", str(exception))
 

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -448,7 +448,6 @@ class TestResult:
     interactions: List[Interaction] = attr.ib(factory=list)  # pragma: no mutate
     logs: List[LogRecord] = attr.ib(factory=list)  # pragma: no mutate
     is_errored: bool = attr.ib(default=False)  # pragma: no mutate
-    is_failed: bool = attr.ib(default=False)  # pragma: no mutate
     seed: Optional[int] = attr.ib(default=None)  # pragma: no mutate
     # To show a proper reproduction code if a failure happens
     overridden_headers: Optional[Dict[str, Any]] = attr.ib(default=None)  # pragma: no mutate
@@ -456,16 +455,13 @@ class TestResult:
     def mark_errored(self) -> None:
         self.is_errored = True
 
-    def mark_failed(self) -> None:
-        self.is_failed = True
-
     @property
     def has_errors(self) -> bool:
         return bool(self.errors)
 
     @property
     def has_failures(self) -> bool:
-        return self.is_failed or any(check.value == Status.failure for check in self.checks)
+        return any(check.value == Status.failure for check in self.checks)
 
     @property
     def has_logs(self) -> bool:

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -605,7 +605,7 @@ def test_flaky(cli, cli_args, workers):
 
 
 @pytest.mark.endpoints("invalid")
-@pytest.mark.parametrize("workers", (1, 2))
+@pytest.mark.parametrize("workers", (1,))
 def test_invalid_endpoint(cli, cli_args, workers):
     # When the app's schema contains errors
     # For example if its type is "int" but should be "integer"
@@ -618,9 +618,14 @@ def test_invalid_endpoint(cli, cli_args, workers):
     # And this endpoint should be marked as errored in the progress line
     lines = result.stdout.split("\n")
     if workers == 1:
-        assert lines[10].startswith("POST /api/invalid F")
+        assert lines[10].startswith("POST /api/invalid E")
     else:
-        assert lines[10] == "F"
+        assert lines[10] == "E"
+    assert " POST: /api/invalid " in lines[13]
+    # There shouldn't be a section end immediately after section start - there should be some error text
+    # An internal error happened during a test run
+    # Error: AssertionError
+    assert not lines[14].startswith("=")
 
 
 @pytest.mark.endpoints("invalid")


### PR DESCRIPTION
Resolves #622