### PR TITLE
feat: pass original case's response to add_case hook

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 Added
 ~~~~~
 
+- pass original case's response to ``add_case`` hook.
 - support for multiple examples with OpenAPI ``examples``. `#589`_
 - ``--verbosity`` CLI option to minimize the error output. `#598`_
 

--- a/src/schemathesis/hooks.py
+++ b/src/schemathesis/hooks.py
@@ -9,6 +9,7 @@ from hypothesis import strategies as st
 
 from .models import Case, Endpoint
 from .types import GenericTest, Hook
+from .utils import GenericResponse
 
 
 def warn_deprecated_hook(hook: Hook) -> None:
@@ -231,10 +232,10 @@ def before_add_examples(context: HookContext, examples: List[Case]) -> None:
 
 
 @HookDispatcher.register_spec([HookScope.GLOBAL])
-def add_case(context: HookContext, case: Case) -> Case:
-    """Creates an additional test per endpoint.
+def add_case(context: HookContext, case: Case, response: GenericResponse) -> Optional[Case]:
+    """Creates an additional test per endpoint. If this hook returns None, no additional test created.
 
-    Called before request is sent with a copy of the original case object.
+    Called with a copy of the original case object and the server's response to the original case.
     """
 
 


### PR DESCRIPTION
Updates:
- Allow user to not create an additional test case by returning None
- Pass the server response from the parent case to its child cases

Purpose:
- Allows user to create additional tests conditionally. For example, user may only want to create an additional test if the parent case received a 2xx response.