### PR TITLE
feat: Allow register function-level hooks without passing their name as the first argument to `apply`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,10 @@ Changelog
 Added
 ~~~~~
 
-- pass original case's response to ``add_case`` hook.
-- support for multiple examples with OpenAPI ``examples``. `#589`_
+- Pass original case's response to ``add_case`` hook.
+- Support for multiple examples with OpenAPI ``examples``. `#589`_
 - ``--verbosity`` CLI option to minimize the error output. `#598`_
+- Allow register function-level hooks without passing their name as the first argument to ``apply``. `#618`_
 
 Changed
 ~~~~~~~
@@ -1134,6 +1135,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#621: https://github.com/kiwicom/schemathesis/issues/621
+.. _#618: https://github.com/kiwicom/schemathesis/issues/618
 .. _#614: https://github.com/kiwicom/schemathesis/issues/614
 .. _#612: https://github.com/kiwicom/schemathesis/issues/612
 .. _#600: https://github.com/kiwicom/schemathesis/issues/600

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -140,7 +140,7 @@ class BaseSchema(Mapping):
         warn_deprecated_hook(hook)
         if place not in HookLocation.__members__:
             raise KeyError(place)
-        self.hooks.register_hook_with_name(f"before_generate_{place}", hook, skip_validation=True)
+        self.hooks.register_hook_with_name(hook, f"before_generate_{place}", skip_validation=True)
 
     @deprecated("'with_hook` is deprecated, use `hooks.apply' instead")
     def with_hook(self, place: str, hook: Hook) -> Callable[[GenericTest], GenericTest]:
@@ -149,7 +149,7 @@ class BaseSchema(Mapping):
         if place not in HookLocation.__members__:
             raise KeyError(place)
 
-        return self.hooks.apply(f"before_generate_{place}", hook, skip_validation=True)
+        return self.hooks.apply(hook, name=f"before_generate_{place}", skip_validation=True)
 
     def get_local_hook_dispatcher(self) -> Optional[HookDispatcher]:
         """Get a HookDispatcher instance bound to the test if present."""

--- a/test/hooks/test_hooks.py
+++ b/test/hooks/test_hooks.py
@@ -92,14 +92,14 @@ from hypothesis import strategies as st
 def replacement(context, strategy):
     return st.just({"id": "foobar"})
 
-@schema.hooks.apply("before_generate_query", replacement)
+@schema.hooks.apply(replacement, name="before_generate_query")
 @schema.parametrize()
 @settings(max_examples=1)
 def test_a(case):
     assert case.query["id"] == "foobar"
 
 @schema.parametrize()
-@schema.hooks.apply("before_generate_query", replacement)
+@schema.hooks.apply(replacement, name="before_generate_query")
 @settings(max_examples=1)
 def test_b(case):
     assert case.query["id"] == "foobar"
@@ -107,13 +107,13 @@ def test_b(case):
 def another_replacement(context, strategy):
     return st.just({"id": "foobaz"})
 
-def third_replacement(context, strategy):
+def before_generate_headers(context, strategy):
     return st.just({"value": "spam"})
 
 @schema.parametrize()
-@schema.hooks.apply("before_generate_query", another_replacement)  # Higher priority
-@schema.hooks.apply("before_generate_query", replacement)
-@schema.hooks.apply("before_generate_headers", third_replacement)
+@schema.hooks.apply(another_replacement, name="before_generate_query")  # Higher priority
+@schema.hooks.apply(replacement, name="before_generate_query")
+@schema.hooks.apply(before_generate_headers)
 @settings(max_examples=1)
 def test_c(case):
     assert case.query["id"] == "foobaz"
@@ -189,7 +189,7 @@ def test_local_dispatcher(schema, apply_first):
         return strategy
 
     # And order of decorators is any
-    apply = schema.hooks.apply("before_generate_cookies", local_hook)
+    apply = schema.hooks.apply(local_hook, name="before_generate_cookies")
     parametrize = schema.parametrize()
     if apply_first:
         wrap = lambda x: parametrize(apply(x))
@@ -293,7 +293,7 @@ def another_hook(context, examples):
 IDX = 0
 
 @schema.parametrize()
-@schema.hooks.apply("before_add_examples", another_hook)
+@schema.hooks.apply(another_hook, name="before_add_examples")
 @settings(phases=[Phase.explicit])
 def test_b(case):
     global IDX


### PR DESCRIPTION
Resolves #618