### PR TITLE
Fix schema loader to parse numbers in scientific notation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Schema validation error on schemas containing numeric values in scientific notation without a dot. `#629`_
+
 `1.9.0`_ - 2020-06-20
 ---------------------
 
@@ -29,7 +34,6 @@ Fixed
 - Crash during generation of loosely-defined headers. `#621`_
 - Show exception information for test runs on invalid schemas with ``--validate-schema=false`` command-line option.
   Before the output sections for invalid endpoints were empty. `#622`_
-- Schema validation error on schemas containing numeric values in scientific notation without a dot. `#629`_
 
 `1.8.0`_ - 2020-06-15
 ---------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,7 @@ Fixed
 - Crash during generation of loosely-defined headers. `#621`_
 - Show exception information for test runs on invalid schemas with ``--validate-schema=false`` command-line option.
   Before the output sections for invalid endpoints were empty. `#622`_
+- Schema validation error on schemas containing numeric values in scientific notation without a dot. `#629`_
 
 `1.8.0`_ - 2020-06-15
 ---------------------

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -169,6 +169,20 @@ def make_loader(*tags_to_remove: str) -> Type[yaml.SafeLoader]:
         key: [(tag, regexp) for tag, regexp in mapping if tag not in tags_to_remove]
         for key, mapping in cls.yaml_implicit_resolvers.copy().items()
     }
+
+    # Fix pyyaml scientific notation parse bug
+    # See PR: https://github.com/yaml/pyyaml/pull/174 for upstream fix
+    cls.add_implicit_resolver(
+        'tag:yaml.org,2002:float',
+        re.compile(r'''^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+                       |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
+                       |\.[0-9_]+(?:[eE][-+]?[0-9]+)?
+                       |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*
+                       |[-+]?\.(?:inf|Inf|INF)
+                       |\.(?:nan|NaN|NAN))$''', re.X),
+        list(u'-+0123456789.'),
+    )
+
     return cls
 
 

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -172,7 +172,7 @@ def make_loader(*tags_to_remove: str) -> Type[yaml.SafeLoader]:
 
     # Fix pyyaml scientific notation parse bug
     # See PR: https://github.com/yaml/pyyaml/pull/174 for upstream fix
-    cls.add_implicit_resolver(
+    cls.add_implicit_resolver(  # type: ignore
         'tag:yaml.org,2002:float',
         re.compile(r'''^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
                        |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)

--- a/src/schemathesis/utils.py
+++ b/src/schemathesis/utils.py
@@ -173,14 +173,17 @@ def make_loader(*tags_to_remove: str) -> Type[yaml.SafeLoader]:
     # Fix pyyaml scientific notation parse bug
     # See PR: https://github.com/yaml/pyyaml/pull/174 for upstream fix
     cls.add_implicit_resolver(  # type: ignore
-        'tag:yaml.org,2002:float',
-        re.compile(r'''^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
+        "tag:yaml.org,2002:float",
+        re.compile(
+            r"""^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+]?[0-9]+)?
                        |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
                        |\.[0-9_]+(?:[eE][-+]?[0-9]+)?
                        |[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*
                        |[-+]?\.(?:inf|Inf|INF)
-                       |\.(?:nan|NaN|NAN))$''', re.X),
-        list(u'-+0123456789.'),
+                       |\.(?:nan|NaN|NAN))$""",
+            re.X,
+        ),
+        list("-+0123456789."),
     )
 
     return cls

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 import schemathesis
@@ -79,10 +80,7 @@ def test_number_deserializing(testdir):
                             "name": "key",
                             "in": "query",
                             "required": True,
-                            "schema": {
-                                "type": "number",
-                                "multipleOf": 0.00001,
-                            },
+                            "schema": {"type": "number", "multipleOf": 0.00001,},
                         }
                     ],
                     "responses": {"200": {"description": "OK"}},
@@ -93,4 +91,7 @@ def test_number_deserializing(testdir):
 
     schema_path = testdir.makefile(".yaml", schema=json.dumps(schema))
     # Then yaml loader should parse them without schema validation errors
-    schemathesis.from_path(str(schema_path))
+    parsed = schemathesis.from_path(str(schema_path))
+    # and the value should be a number
+    value = parsed.raw_schema["paths"]["/teapot"]["get"]["parameters"][0]["schema"]["multipleOf"]
+    assert isinstance(value, float)

--- a/test/test_loaders.py
+++ b/test/test_loaders.py
@@ -65,7 +65,6 @@ def test_operation_id(operation_id):
         assert endpoint.definition.raw["operationId"] == operation_id
 
 
-@pytest.mark.hypothesis_nested
 def test_number_deserializing(testdir):
     # When numbers in schema are written in scientific notation but without a dot (achieved by dumping the schema with json.dumps)
     schema = {


### PR DESCRIPTION
`pyyaml` parses numbers in scientific notation without a dot as strings:
https://github.com/yaml/pyyaml/issues/173
https://github.com/yaml/pyyaml/pull/174

This PR presents a temporary solution until the issue is resolved upstream.