### PR TITLE
feat: Support ASGI applications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ To speed up the testing process Schemathesis provides ``-w/--workers`` option fo
 
 In the example above all tests will be distributed among 8 worker threads.
 
-If you'd like to test your web app (Flask or AioHTTP for example) then there is ``--app`` option for you:
+If you'd like to test your web app (Flask or AioHTTP or FastAPI for example) then there is ``--app`` option for you:
 
 .. code:: bash
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 
 `Unreleased`_
 -------------
+Added
+~~~~~
+
+- ``loaders.from_asgi`` supports making calls to ASGI-compliant application (For example: FastAPI). `#521`_
 
 `1.9.1`_ - 2020-06-21
 ---------------------
@@ -1179,6 +1183,7 @@ Fixed
 .. _#521: https://github.com/kiwicom/schemathesis/issues/521
 .. _#519: https://github.com/kiwicom/schemathesis/issues/519
 .. _#513: https://github.com/kiwicom/schemathesis/issues/513
+.. _#512: https://github.com/kiwicom/schemathesis/issues/512
 .. _#504: https://github.com/kiwicom/schemathesis/issues/504
 .. _#503: https://github.com/kiwicom/schemathesis/issues/503
 .. _#499: https://github.com/kiwicom/schemathesis/issues/499

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ click = "^7.0"
 importlib_metadata = { version = "^1.1", python = "<3.8" }
 werkzeug = ">0.16.0"
 junit-xml = "^1.9"
-starlette = "^0"
+starlette = "^0.13.2"
 
 [tool.poetry.dev-dependencies]
 coverage = "^4.5"
@@ -48,6 +48,7 @@ pytest-asyncio = "^0.11.0"
 pytest-xdist = "^1.30"
 typing_extensions = "^3.7"
 flask = "^1.1"
+fastapi = "^0.58.0"
 sphinx = "^3.0.3"
 
 [tool.poetry.plugins]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ click = "^7.0"
 importlib_metadata = { version = "^1.1", python = "<3.8" }
 werkzeug = ">0.16.0"
 junit-xml = "^1.9"
+starlette = "^0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^4.5"
@@ -66,7 +67,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "urllib3", "werkzeug", "yaml"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "schemathesis"
-known_third_party = ["_pytest", "aiohttp", "attr", "click", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml"]
+known_third_party = ["_pytest", "aiohttp", "attr", "click", "fastapi", "flask", "hypothesis", "hypothesis_jsonschema", "jsonschema", "junit_xml", "packaging", "pytest", "pytest_subtests", "requests", "schemathesis", "starlette", "urllib3", "werkzeug", "yaml"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -148,7 +148,7 @@ def schemathesis(pre_run: Optional[str] = None) -> None:
     type=str,
     callback=callbacks.validate_base_url,
 )
-@click.option("--app", help="WSGI application to test.", type=str, callback=callbacks.validate_app)
+@click.option("--app", help="WSGI/ASGI application to test.", type=str, callback=callbacks.validate_app)
 @click.option(
     "--request-timeout",
     help="Timeout in milliseconds for network requests during the test run.",

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -276,6 +276,7 @@ def load_schema(
             # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with
             # the given app
             loader = loaders.get_loader_for_app(app)
+            loader_options.update(dict_true_values(headers=headers))
         else:
             loader_options.update(dict_true_values(headers=headers, auth=auth, auth_type=auth_type))
 

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -18,6 +18,7 @@ from .impl import (
     SingleThreadASGIRunner,
     SingleThreadRunner,
     SingleThreadWSGIRunner,
+    ThreadPoolASGIRunner,
     ThreadPoolRunner,
     ThreadPoolWSGIRunner,
 )
@@ -179,23 +180,7 @@ def execute_from_schema(
 
         runner: BaseRunner
         if workers_num > 1:
-            if schema.app:
-                runner = ThreadPoolWSGIRunner(
-                    schema=schema,
-                    checks=checks,
-                    targets=targets,
-                    hypothesis_settings=hypothesis_options,
-                    auth=auth,
-                    auth_type=auth_type,
-                    headers=headers,
-                    seed=seed,
-                    workers_num=workers_num,
-                    exit_first=exit_first,
-                    store_interactions=store_interactions,
-                    stateful=stateful,
-                    stateful_recursion_limit=stateful_recursion_limit,
-                )
-            else:
+            if not schema.app:
                 runner = ThreadPoolRunner(
                     schema=schema,
                     checks=checks,
@@ -212,6 +197,39 @@ def execute_from_schema(
                     stateful=stateful,
                     stateful_recursion_limit=stateful_recursion_limit,
                 )
+            elif isinstance(schema.app, Starlette):
+                runner = ThreadPoolASGIRunner(
+                    schema=schema,
+                    checks=checks,
+                    targets=targets,
+                    hypothesis_settings=hypothesis_options,
+                    auth=auth,
+                    auth_type=auth_type,
+                    headers=headers,
+                    seed=seed,
+                    exit_first=exit_first,
+                    store_interactions=store_interactions,
+                    stateful=stateful,
+                    stateful_recursion_limit=stateful_recursion_limit,
+                )
+
+            else:
+                runner = ThreadPoolWSGIRunner(
+                    schema=schema,
+                    checks=checks,
+                    targets=targets,
+                    hypothesis_settings=hypothesis_options,
+                    auth=auth,
+                    auth_type=auth_type,
+                    headers=headers,
+                    seed=seed,
+                    workers_num=workers_num,
+                    exit_first=exit_first,
+                    store_interactions=store_interactions,
+                    stateful=stateful,
+                    stateful_recursion_limit=stateful_recursion_limit,
+                )
+
         else:
             if not schema.app:
                 runner = SingleThreadRunner(

--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -312,7 +312,6 @@ def load_schema(
             # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with
             # the given app
             loader = loaders.get_loader_for_app(app)
-            loader_options.update(dict_true_values(headers=headers))
         else:
             loader_options.update(dict_true_values(headers=headers, auth=auth, auth_type=auth_type))
 

--- a/src/schemathesis/runner/impl/__init__.py
+++ b/src/schemathesis/runner/impl/__init__.py
@@ -1,3 +1,3 @@
 from .core import DEFAULT_STATEFUL_RECURSION_LIMIT, BaseRunner
 from .solo import SingleThreadASGIRunner, SingleThreadRunner, SingleThreadWSGIRunner
-from .threadpool import ThreadPoolRunner, ThreadPoolWSGIRunner
+from .threadpool import ThreadPoolASGIRunner, ThreadPoolRunner, ThreadPoolWSGIRunner

--- a/src/schemathesis/runner/impl/__init__.py
+++ b/src/schemathesis/runner/impl/__init__.py
@@ -1,3 +1,3 @@
 from .core import DEFAULT_STATEFUL_RECURSION_LIMIT, BaseRunner
-from .solo import SingleThreadRunner, SingleThreadWSGIRunner
+from .solo import SingleThreadASGIRunner, SingleThreadRunner, SingleThreadWSGIRunner
 from .threadpool import ThreadPoolRunner, ThreadPoolWSGIRunner

--- a/src/schemathesis/runner/impl/solo.py
+++ b/src/schemathesis/runner/impl/solo.py
@@ -6,7 +6,7 @@ import attr
 from ...models import TestResultSet
 from ...utils import get_requests_auth
 from .. import events
-from .core import BaseRunner, get_session, network_test, wsgi_test
+from .core import BaseRunner, asgi_test, get_session, network_test, wsgi_test
 
 
 @attr.s(slots=True)  # pragma: no mutate
@@ -44,6 +44,22 @@ class SingleThreadWSGIRunner(SingleThreadRunner):
             results=results,
             auth=self.auth,
             auth_type=self.auth_type,
+            headers=self.headers,
+            store_interactions=self.store_interactions,
+        )
+
+
+@attr.s(slots=True)  # pragma: no mutate
+class SingleThreadASGIRunner(SingleThreadRunner):
+    def _execute(self, results: TestResultSet) -> Generator[events.ExecutionEvent, None, None]:
+        yield from self._run_tests(
+            self.schema.get_all_tests,
+            asgi_test,
+            self.hypothesis_settings,
+            self.seed,
+            checks=self.checks,
+            targets=self.targets,
+            results=results,
             headers=self.headers,
             store_interactions=self.store_interactions,
         )

--- a/test/apps/_fastapi/__init__.py
+++ b/test/apps/_fastapi/__init__.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+
+def create_app():
+    app = FastAPI()
+
+    @app.get("/users")
+    async def root():
+        return {"success": True}
+
+    return app

--- a/test/apps/_fastapi/app.py
+++ b/test/apps/_fastapi/app.py
@@ -1,0 +1,3 @@
+from . import create_app
+
+app = create_app()

--- a/test/cli/test_asgi.py
+++ b/test/cli/test_asgi.py
@@ -1,0 +1,24 @@
+from _pytest.main import ExitCode
+
+
+def test_wsgi_app(testdir, cli):
+    module = testdir.make_importable_pyfile(
+        location="""
+        from fastapi import FastAPI
+        from fastapi import HTTPException
+
+        app = FastAPI()
+
+        @app.get("/api/success")
+        async def success():
+            return {"success": True}
+
+        @app.get("/api/failure")
+        async def failure():
+            raise HTTPException(status_code=500)
+            return {"failure": True}
+        """
+    )
+    result = cli.run("/openapi.json", "--app", f"{module.purebasename}:app")
+    assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
+    assert "1 passed, 1 failed in" in result.stdout

--- a/test/cli/test_asgi.py
+++ b/test/cli/test_asgi.py
@@ -1,3 +1,4 @@
+import pytest
 from _pytest.main import ExitCode
 
 
@@ -22,3 +23,40 @@ def test_wsgi_app(testdir, cli):
     result = cli.run("/openapi.json", "--app", f"{module.purebasename}:app")
     assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
     assert "1 passed, 1 failed in" in result.stdout
+
+
+@pytest.mark.parametrize("workers", (1, 2))
+def test_cli_run_output_success(testdir, cli, workers):
+    module = testdir.make_importable_pyfile(
+        location="""
+            from fastapi import FastAPI
+            from fastapi import HTTPException
+
+            app = FastAPI()
+
+            @app.get("/api/success")
+            async def success():
+                return {"success": True}
+
+            """
+    )
+    result = cli.run(
+        "/openapi.json", "--app", f"{module.purebasename}:app", f"--workers={workers}", "--show-errors-tracebacks"
+    )
+
+    assert result.exit_code == ExitCode.OK, result.stdout
+    lines = result.stdout.split("\n")
+    assert lines[7] == f"Workers: {workers}"
+    if workers == 1:
+        assert lines[10].startswith("GET /api/success .")
+    else:
+        assert lines[10] == "."
+    assert " HYPOTHESIS OUTPUT " not in result.stdout
+    assert " SUMMARY " in result.stdout
+
+    lines = result.stdout.strip().split("\n")
+    last_line = lines[-1]
+    assert "== 1 passed in " in last_line
+    # And the running time is a small positive number
+    time = float(last_line.split(" ")[-2].replace("s", ""))
+    assert 0 <= time < 5

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -187,7 +187,7 @@ def test_commands_run_help(cli):
         "  -b, --base-url TEXT             Base URL address of the API, required for",
         "                                  SCHEMA if specified by file.",
         "",
-        "  --app TEXT                      WSGI application to test.",
+        "  --app TEXT                      WSGI/ASGI application to test.",
         "  --request-timeout INTEGER RANGE",
         "                                  Timeout in milliseconds for network requests",
         "                                  during the test run.",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,7 +8,7 @@ from hypothesis import settings
 import schemathesis.cli
 from schemathesis.extra._aiohttp import run_server
 
-from .apps import Endpoint, _aiohttp, _flask
+from .apps import Endpoint, _aiohttp, _fastapi, _flask
 from .utils import make_schema
 
 pytest_plugins = ["pytester", "aiohttp.pytest_plugin", "pytest_mock"]
@@ -359,6 +359,11 @@ def testdir(testdir):
 @pytest.fixture()
 def flask_app(endpoints):
     return _flask.create_app(endpoints)
+
+
+@pytest.fixture()
+def fastapi_app():
+    return _fastapi.create_app()
 
 
 def make_importable(module):

--- a/test/test_asgi.py
+++ b/test/test_asgi.py
@@ -68,7 +68,7 @@ def test_cookies(fastapi_app):
     test()
 
 
-def test_not_wsgi(schema):
+def test_not_app_with_asgi(schema):
     case = Case(schema.endpoints["/users"]["GET"])
     case.endpoint.app = None
     with pytest.raises(

--- a/test/test_asgi.py
+++ b/test/test_asgi.py
@@ -1,0 +1,79 @@
+import pytest
+from fastapi import Cookie
+from hypothesis import HealthCheck, given, settings
+
+import schemathesis
+from schemathesis import Case
+from schemathesis.loaders import from_asgi
+
+from .apps._fastapi import create_app
+
+
+@pytest.fixture()
+def schema():
+    return from_asgi("/openapi.json", create_app())
+
+
+@pytest.mark.hypothesis_nested
+def test_call(schema, simple_schema):
+    strategy = schema.endpoints["/users"]["GET"].as_strategy()
+
+    @given(case=strategy)
+    def test(case):
+        response = case.call_asgi()
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+
+    test()
+
+
+@pytest.mark.hypothesis_nested
+def test_cookies(fastapi_app):
+    @fastapi_app.get("/cookies")
+    def cookies(token: str = Cookie(None)):
+        return {"token": token}
+
+    schema = schemathesis.from_dict(
+        {
+            "openapi": "3.0.2",
+            "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+            "paths": {
+                "/cookies": {
+                    "get": {
+                        "parameters": [
+                            {
+                                "name": "token",
+                                "in": "cookie",
+                                "required": True,
+                                "schema": {"type": "string", "enum": ["test"]},
+                            }
+                        ],
+                        "responses": {"200": {"description": "OK"}},
+                    }
+                }
+            },
+        },
+        app=fastapi_app,
+    )
+
+    strategy = schema.endpoints["/cookies"]["GET"].as_strategy()
+
+    @given(case=strategy)
+    @settings(max_examples=3, suppress_health_check=[HealthCheck.filter_too_much])
+    def test(case):
+        response = case.call_asgi()
+        assert response.status_code == 200
+        assert response.json() == {"token": "test"}
+
+    test()
+
+
+def test_not_wsgi(schema):
+    case = Case(schema.endpoints["/users"]["GET"])
+    case.endpoint.app = None
+    with pytest.raises(
+        RuntimeError,
+        match="ASGI application instance is required. "
+        "Please, set `app` argument in the schema constructor or pass it to `call_asgi`",
+    ):
+        case.call_asgi()

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 deps =
   aiohttp
   flask
+  fastapi
   coverage
   pytest-asyncio
   pytest-mock
@@ -20,6 +21,7 @@ commands =
 deps =
   aiohttp
   flask
+  fastapi
   coverage
   pytest<5.4
   pytest-asyncio<0.11.0


### PR DESCRIPTION
> This commit adds support to run ASGI applications directly from CLI
using --app option or in-code using from_asgi.
It is currently based on Starlette's TestClient.

Base on #512 
On the basis of this, we add some code and pass the preliminary test.

- `schemathesis.loaders.from_asgi` get schema
- `schemathesis.models.Case.call_asgi` using `starlette.testclient.TestClient` call API
