### PR TITLE
fix: Passing `headers` to `loader_for_app`

### DIFF
--- a/src/schemathesis/runner/__init__.py
+++ b/src/schemathesis/runner/__init__.py
@@ -312,6 +312,7 @@ def load_schema(
             # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with
             # the given app
             loader = loaders.get_loader_for_app(app)
+            loader_options.update(dict_true_values(headers=headers))
         else:
             loader_options.update(dict_true_values(headers=headers, auth=auth, auth_type=auth_type))
 

--- a/test/cli/test_commands.py
+++ b/test/cli/test_commands.py
@@ -344,6 +344,21 @@ def test_load_schema_arguments(cli, mocker, args, expected):
     assert load_schema.call_args[1] == expected
 
 
+def test_load_schema_arguments_headers_to_loader_for_app(testdir, cli, mocker):
+    from_wsgi = mocker.patch("schemathesis.loaders.from_wsgi", autospec=True)
+
+    module = testdir.make_importable_pyfile(
+        location="""
+        from test.apps._flask import create_app
+
+        app = create_app()
+        """
+    )
+    cli.run("/swagger.yaml", "--app", f"{module.purebasename}:app", "-H", "Authorization: Bearer 123")
+
+    assert from_wsgi.call_args[1]["headers"]["Authorization"] == "Bearer 123"
+
+
 def test_all_checks(cli, mocker):
     execute = mocker.patch("schemathesis.runner.execute_from_schema", autospec=True)
     result = cli.run(SCHEMA_URI, "--checks=all")


### PR DESCRIPTION
When  use `--app` arguments， custom header arguments is miss.
In a project, accessing the schame require authentication, which may cause the program to fail