### PR TITLE
feat: support property-level examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,8 +344,7 @@ Or add this decorator to your test if you use Schemathesis in your Python tests:
     def test_api(case):
         ...
 
-**NOTE**. Schemathesis does not support examples in individual properties that are specified inside Schema Object.
-But examples in `Parameter Object <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameter-object>`_, `Media Type Object <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject>`_ and `Schema Object <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#schema-object>`_ are supported.
+**NOTE**. Schemathesis supports examples in individual properties.
 See below:
 
 .. code:: yaml
@@ -356,10 +355,12 @@ See below:
         parameters:
           - in: query
             name: foo
-            example: bar  # SUPPORTED!
             schema:
-              type: string
-              example: spam  # SUPPORTED!
+              type: object
+              properties:
+                prop1:
+                  type: string
+                  example: prop1 example    # SUPPORTED!
         post:
           requestBody:
             content:
@@ -369,7 +370,7 @@ See below:
                   properties:
                     foo:
                       type: string
-                      example: bar  # NOT SUPPORTED!
+                      example: bar          # SUPPORTED!
 
 Direct strategies access
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- support for property-level examples. `#637`_
+
 `2.0.0`_ - 2020-07-01
 ---------------------
 
@@ -1204,6 +1209,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#467: https://github.com/kiwicom/schemathesis/issues/467
 .. _#631: https://github.com/kiwicom/schemathesis/issues/631
 .. _#629: https://github.com/kiwicom/schemathesis/issues/629
 .. _#621: https://github.com/kiwicom/schemathesis/issues/621

--- a/src/schemathesis/specs/openapi/examples.py
+++ b/src/schemathesis/specs/openapi/examples.py
@@ -6,26 +6,71 @@ from ..._hypothesis import LOCATION_TO_CONTAINER, PARAMETERS, _get_case_strategy
 from ...models import Case, Endpoint
 
 
-def get_param_examples(endpoint_def: Dict[str, Any], examples_field: str) -> List[Dict[str, Any]]:
+def get_object_example_from_properties(object_schema: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        prop_name: prop["example"]
+        for prop_name, prop in object_schema.get("properties", {}).items()
+        if "example" in prop
+    }
+
+
+def get_parameter_examples(endpoint_def: Dict[str, Any], examples_field: str) -> List[Dict[str, Any]]:
+    """Gets parameter examples from OAS3 `examples` keyword or `x-examples` for Swagger 2."""
+
     return [
         {
-            "type": LOCATION_TO_CONTAINER.get(param["in"]),
-            "name": param["name"],
-            "examples": [example["value"] for example in param[examples_field].values()],
+            "type": LOCATION_TO_CONTAINER.get(parameter["in"]),
+            "name": parameter["name"],
+            "examples": [example["value"] for example in parameter[examples_field].values()],
         }
-        for param in endpoint_def.get("parameters", [])
-        if examples_field in param
+        for parameter in endpoint_def.get("parameters", [])
+        if examples_field in parameter
     ]
 
 
+def get_parameter_example_from_properties(endpoint_def: Dict[str, Any]) -> Dict[str, Any]:
+    static_parameters: Dict[str, Any] = {}
+    for parameter in endpoint_def.get("parameters", []):
+        parameter_schema = parameter["schema"] if "schema" in parameter else parameter
+        example = get_object_example_from_properties(parameter_schema)
+        if example:
+            parameter_type = LOCATION_TO_CONTAINER[parameter["in"]]
+            if parameter_type not in ("body", "form_data"):
+                if parameter_type not in static_parameters:
+                    static_parameters[parameter_type] = {}
+                static_parameters[parameter_type][parameter["name"]] = example
+            else:
+                # swagger 2 body and formData parameters should not include parameter name
+                static_parameters[parameter_type] = example
+    return static_parameters
+
+
 def get_request_body_examples(endpoint_def: Dict[str, Any], examples_field: str) -> Dict[str, Any]:
+    """Gets request body examples from OAS3 `examples` keyword or `x-examples` for Swagger 2."""
+
     request_bodies_items = endpoint_def.get("requestBody", {}).get("content", {}).items()
     if not request_bodies_items:
         return {}
     # first element in tuple in media type, second element is dict
     media_type, schema = next(iter(request_bodies_items))
-    param_type = "body" if media_type != "multipart/form-data" else "form_data"
-    return {"type": param_type, "examples": [example["value"] for example in schema.get(examples_field, {}).values()]}
+    parameter_type = "body" if media_type != "multipart/form-data" else "form_data"
+    return {
+        "type": parameter_type,
+        "examples": [example["value"] for example in schema.get(examples_field, {}).values()],
+    }
+
+
+def get_request_body_example_from_properties(endpoint_def: Dict[str, Any]) -> Dict[str, Any]:
+    static_parameters: Dict[str, Any] = {}
+    request_bodies_items = endpoint_def.get("requestBody", {}).get("content", {}).items()
+    if request_bodies_items:
+        media_type, request_body_schema = next(iter(request_bodies_items))
+        example = get_object_example_from_properties(request_body_schema.get("schema", {}))
+        if example:
+            request_body_type = "body" if media_type != "multipart/form-data" else "form_data"
+            static_parameters[request_body_type] = example
+
+    return static_parameters
 
 
 def get_static_parameters_from_example(endpoint: Endpoint) -> Dict[str, Any]:
@@ -38,21 +83,31 @@ def get_static_parameters_from_example(endpoint: Endpoint) -> Dict[str, Any]:
 
 
 def get_static_parameters_from_examples(endpoint: Endpoint, examples_field: str) -> List[Dict[str, Any]]:
+    """Get static parameters from OpenAPI examples keyword."""
     endpoint_def = endpoint.definition.resolved
     return merge_examples(
-        get_param_examples(endpoint_def, examples_field), get_request_body_examples(endpoint_def, examples_field)
+        get_parameter_examples(endpoint_def, examples_field), get_request_body_examples(endpoint_def, examples_field)
     )
+
+
+def get_static_parameters_from_properties(endpoint: Endpoint) -> Dict[str, Any]:
+    endpoint_def = endpoint.definition.resolved
+    return {
+        **get_parameter_example_from_properties(endpoint_def),
+        **get_request_body_example_from_properties(endpoint_def),
+    }
 
 
 def get_strategies_from_examples(endpoint: Endpoint, examples_field: str = "examples") -> List[SearchStrategy[Case]]:
     strategies = [
         get_strategy(endpoint, static_parameters)
         for static_parameters in get_static_parameters_from_examples(endpoint, examples_field)
+        if static_parameters
     ]
-    static_parameters = get_static_parameters_from_example(endpoint)
-    if static_parameters:
-        strategy = get_strategy(endpoint, get_static_parameters_from_example(endpoint))
-        strategies.append(strategy)
+    for static_parameters in static_parameters_union(
+        get_static_parameters_from_example(endpoint), get_static_parameters_from_properties(endpoint)
+    ):
+        strategies.append(get_strategy(endpoint, static_parameters))
     return strategies
 
 
@@ -71,22 +126,51 @@ def merge_examples(
     parameter_examples: List[Dict[str, Any]], request_body_examples: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
     """Create list of static parameter objects from parameter and request body examples."""
-    static_param_list = []
+    static_parameter_list = []
     for idx in range(num_examples(parameter_examples, request_body_examples)):
         static_parameters: Dict[str, Any] = {}
-        for param in parameter_examples:
-            if param["type"] not in static_parameters:
-                static_parameters[param["type"]] = {}
-            static_parameters[param["type"]][param["name"]] = param["examples"][min(idx, len(param["examples"]) - 1)]
+        for parameter in parameter_examples:
+            if parameter["type"] not in static_parameters:
+                static_parameters[parameter["type"]] = {}
+            static_parameters[parameter["type"]][parameter["name"]] = parameter["examples"][
+                min(idx, len(parameter["examples"]) - 1)
+            ]
         if "examples" in request_body_examples:
             static_parameters[request_body_examples["type"]] = request_body_examples["examples"][
                 min(idx, len(request_body_examples["examples"]) - 1)
             ]
-        static_param_list.append(static_parameters)
-    return static_param_list
+        static_parameter_list.append(static_parameters)
+    return static_parameter_list
+
+
+def static_parameters_union(sp_1: Dict[str, Any], sp_2: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Fill missing parameters in each static parameter dict with parameters provided in the other dict."""
+    full_static_parameters = (_static_parameters_union(sp_1, sp_2), _static_parameters_union(sp_2, sp_1))
+    return [static_parameter for static_parameter in full_static_parameters if static_parameter]
+
+
+def _static_parameters_union(base_obj: Dict[str, Any], fill_obj: Dict[str, Any]) -> Dict[str, Any]:
+    """Fill base_obj with parameter examples in fill_obj that were not in base_obj."""
+    if not base_obj:
+        return {}
+
+    full_static_parameters: Dict[str, Any] = {**base_obj}
+
+    for parameter_type, examples in fill_obj.items():
+        if parameter_type not in full_static_parameters:
+            full_static_parameters[parameter_type] = examples
+        elif parameter_type not in ("body", "form_data"):
+            # copy individual parameter names.
+            # body and form_data are unnamed, single examples, so we only do this for named parameters.
+            for parameter_name, example in examples.items():
+                if parameter_name not in full_static_parameters[parameter_type]:
+                    full_static_parameters[parameter_type][parameter_name] = example
+    return full_static_parameters
 
 
 def num_examples(parameter_examples: List[Dict[str, Any]], request_body_examples: Dict[str, Any]) -> int:
-    max_param_examples = max(len(param["examples"]) for param in parameter_examples) if parameter_examples else 0
+    max_parameter_examples = (
+        max(len(parameter["examples"]) for parameter in parameter_examples) if parameter_examples else 0
+    )
     num_request_body_examples = len(request_body_examples["examples"]) if "examples" in request_body_examples else 0
-    return max(max_param_examples, num_request_body_examples)
+    return max(max_parameter_examples, num_request_body_examples)

--- a/test/data/petstore_v2.yaml
+++ b/test/data/petstore_v2.yaml
@@ -669,6 +669,7 @@ definitions:
           wrapped: true
         items:
           type: "string"
+        example: ["https://photourl.com"]
       tags:
         type: "array"
         xml:

--- a/test/data/petstore_v3.yaml
+++ b/test/data/petstore_v3.yaml
@@ -620,6 +620,7 @@ components:
           xml:
             name: photoUrl
             wrapped: true
+          example: ["https://photourl.com"]
         status:
           description: pet status in the store
           enum:

--- a/test/test_dereferencing.py
+++ b/test/test_dereferencing.py
@@ -39,6 +39,7 @@ def petstore():
                         "items": {"type": "string"},
                         "type": "array",
                         "xml": {"name": "photoUrl", "wrapped": True},
+                        "example": ["https://photourl.com"],
                     },
                     "status": {
                         "description": "pet status in the store",

--- a/test/test_petstore.py
+++ b/test/test_petstore.py
@@ -32,7 +32,7 @@ def test_(request, case):
     assert_requests_call(case)
 """
     )
-    testdir.assert_petstore(2, 10)
+    testdir.assert_petstore(2, 12)
 
 
 def test_find_by_status(testdir):


### PR DESCRIPTION
Related issue: #467 

Updates:
- Process property-level examples.
- Merge property-level examples with schema-level examples provided with `example` keyword.

Tests:
- Update tests that use schemas with property-level examples to reflect additional generated examples.
- Add tests for each function to generate static params from property-level examples.