### PR TITLE
test: Add Open API 3.0 test app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -558,12 +558,12 @@ Then you could use CLI against this server:
 
 .. code:: bash
 
-    schemathesis run http://127.0.0.1:8081/swagger.yaml
+    schemathesis run http://127.0.0.1:8081/schema.yaml
     ================================== Schemathesis test session starts =================================
     platform Linux -- Python 3.7.4, schemathesis-0.12.2, hypothesis-4.39.0, hypothesis_jsonschema-0.9.8
     rootdir: /
     hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/.hypothesis/examples')
-    Schema location: http://127.0.0.1:8081/swagger.yaml
+    Schema location: http://127.0.0.1:8081/schema.yaml
     Base URL: http://127.0.0.1:8081
     Specification version: Swagger 2.0
     collected endpoints: 2

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -66,7 +66,7 @@ different algorithms for stateful testing might be implemented in the future.
 
 .. code:: bash
 
-    schemathesis run --stateful=links http://0.0.0.0/swagger.yaml
+    schemathesis run --stateful=links http://0.0.0.0/schema.yaml
 
     ...
 

--- a/docs/targeted.rst
+++ b/docs/targeted.rst
@@ -28,7 +28,7 @@ Let's take a look if Schemathesis can discover this issue and how much time it w
 
 .. code:: bash
 
-    $  schemathesis run --hypothesis-max-examples=100000 http://127.0.0.1:8081/swagger.yaml
+    $  schemathesis run --hypothesis-max-examples=100000 http://127.0.0.1:8081/schema.yaml
     ...
     1. Received a response with 5xx status code: 500
 
@@ -51,7 +51,7 @@ And with targeted testing (``.hypothesis`` directory was removed between these t
 
 .. code:: bash
 
-    $  schemathesis run --target=response_time --hypothesis-max-examples=100000 http://127.0.0.1:8081/swagger.yaml
+    $  schemathesis run --target=response_time --hypothesis-max-examples=100000 http://127.0.0.1:8081/schema.yaml
     ...
     1. Received a response with 5xx status code: 500
 

--- a/test/apps/__init__.py
+++ b/test/apps/__init__.py
@@ -8,32 +8,35 @@ from schemathesis.cli import CSVOption
 
 try:
     from . import _aiohttp, _flask, _graphql
-    from .utils import Endpoint
+    from .utils import Endpoint, OpenAPIVersion
 except ImportError:
     import _aiohttp
     import _flask
     import _graphql
-    from utils import Endpoint
+    from utils import Endpoint, OpenAPIVersion
 
 
 @click.command()
 @click.argument("port", type=int)
 @click.option("--endpoints", type=CSVOption(Endpoint))
-@click.option("--framework", type=click.Choice(["aiohttp", "flask", "graphql"]), default="aiohttp")
-def run_app(port: int, endpoints: List[Endpoint], framework: str) -> None:
-    if endpoints is not None:
-        prepared_endpoints = tuple(endpoint.name for endpoint in endpoints)
-    else:
-        prepared_endpoints = tuple(endpoint.name for endpoint in Endpoint)
-    if framework == "aiohttp":
-        app = _aiohttp.create_app(prepared_endpoints)
-        web.run_app(app, port=port)
-    elif framework == "flask":
-        app = _flask.create_app(prepared_endpoints)
-        app.run(port=port)
-    elif framework == "graphql":
+@click.option("--spec", type=click.Choice(["openapi2", "openapi3", "graphql"]), default="openapi2")
+@click.option("--framework", type=click.Choice(["aiohttp", "flask"]), default="aiohttp")
+def run_app(port: int, endpoints: List[Endpoint], spec: str, framework: str) -> None:
+    if spec == "graphql":
         app = _graphql.create_app()
         app.run(port=port)
+    else:
+        if endpoints is not None:
+            prepared_endpoints = tuple(endpoint.name for endpoint in endpoints)
+        else:
+            prepared_endpoints = tuple(endpoint.name for endpoint in Endpoint)
+        version = {"openapi2": OpenAPIVersion("2.0"), "openapi3": OpenAPIVersion("3.0"),}[spec]
+        if framework == "aiohttp":
+            app = _aiohttp.create_openapi_app(prepared_endpoints, version)
+            web.run_app(app, port=port)
+        elif framework == "flask":
+            app = _flask.create_openapi_app(prepared_endpoints, version)
+            app.run(port=port)
 
 
 if __name__ == "__main__":

--- a/test/apps/_aiohttp/app.py
+++ b/test/apps/_aiohttp/app.py
@@ -1,3 +1,3 @@
-from . import create_app
+from . import create_openapi_app
 
-app = create_app()
+app = create_openapi_app()

--- a/test/apps/_flask/app.py
+++ b/test/apps/_flask/app.py
@@ -1,3 +1,3 @@
-from . import create_app
+from . import create_openapi_app
 
-app = create_app()
+app = create_openapi_app()

--- a/test/cli/test_cassettes.py
+++ b/test/cli/test_cassettes.py
@@ -75,7 +75,7 @@ def test_main_process_error(cli, schema_url, cassette_path):
 
 
 @pytest.mark.endpoints("__all__")
-async def test_replay(cli, schema_url, app, reset_app, cassette_path):
+async def test_replay(openapi_version, cli, schema_url, app, reset_app, cassette_path):
     # Record a cassette
     result = cli.run(
         schema_url,
@@ -86,7 +86,7 @@ async def test_replay(cli, schema_url, app, reset_app, cassette_path):
     )
     assert result.exit_code == ExitCode.TESTS_FAILED, result.stdout
     # these requests are not needed
-    reset_app()
+    reset_app(openapi_version)
     assert not app["incoming_requests"]
     # When a valid cassette is replayed
     result = cli.replay(str(cassette_path))

--- a/test/cli/test_junitxml.py
+++ b/test/cli/test_junitxml.py
@@ -35,7 +35,7 @@ def test_junitxml_file(cli, schema_url, tmp_path):
     assert testsuite.attrib["errors"] == "1"
     assert testsuite.attrib["failures"] == "1"
     assert testsuite.attrib["tests"] == "3"
-    # Inpected nested `testcase`s
+    # Inspected nested `testcase`s
     testcases = list(testsuite)
     assert len(testcases) == 3
     # Inspected testcase with a failure

--- a/test/extra/test_aiohttp.py
+++ b/test/extra/test_aiohttp.py
@@ -6,7 +6,7 @@ from ..apps import _aiohttp
 
 
 def test_exact_port():
-    app = _aiohttp.create_app(("success", "failure"))
+    app = _aiohttp.create_openapi_app(("success", "failure"))
     run_server(app, 8999)
-    response = requests.get("http://localhost:8999/swagger.yaml")
+    response = requests.get("http://localhost:8999/schema.yaml")
     assert response.status_code == 200

--- a/test/hooks/test_hooks.py
+++ b/test/hooks/test_hooks.py
@@ -25,7 +25,7 @@ def global_hook(request):
 
 @pytest.fixture
 def schema(flask_app):
-    return schemathesis.from_wsgi("/swagger.yaml", flask_app)
+    return schemathesis.from_wsgi("/schema.yaml", flask_app)
 
 
 @pytest.fixture()

--- a/test/specs/openapi/test_links.py
+++ b/test/specs/openapi/test_links.py
@@ -59,7 +59,19 @@ def response():
         (
             "/users/",
             [
-                LINK,
+                Link(
+                    name="GetUserByUserId",
+                    endpoint=Endpoint(
+                        path="/users/{user_id}",
+                        method="GET",
+                        definition=ANY,
+                        schema=ANY,
+                        base_url=ANY,
+                        path_parameters=ANY,
+                        query=ANY,
+                    ),
+                    parameters={"path.user_id": "$response.body#/id", "query.user_id": "$response.body#/id"},
+                ),
                 Link(
                     name="UpdateUserById",
                     endpoint=ANY,

--- a/test/specs/openapi/test_schemas.py
+++ b/test/specs/openapi/test_schemas.py
@@ -4,15 +4,23 @@ from schemathesis.models import Endpoint
 
 
 @pytest.mark.endpoints("get_user", "update_user")
-def test_get_endpoint_via_remote_reference(swagger_20, schema_url):
+def test_get_endpoint_via_remote_reference(openapi_version, swagger_20, schema_url):
     resolved = swagger_20.get_endpoint_by_reference(f"{schema_url}#/paths/~1users~1{{user_id}}/patch")
     assert isinstance(resolved, Endpoint)
     assert resolved.path == "/users/{user_id}"
     assert resolved.method == "PATCH"
     # Via common parameters for all methods
-    assert resolved.query == {
-        "properties": {"common": {"in": "query", "name": "common", "type": "integer"}},
-        "additionalProperties": False,
-        "type": "object",
-        "required": ["common"],
-    }
+    if openapi_version.is_openapi_2:
+        assert resolved.query == {
+            "properties": {"common": {"in": "query", "name": "common", "type": "integer"}},
+            "additionalProperties": False,
+            "type": "object",
+            "required": ["common"],
+        }
+    if openapi_version.is_openapi_3:
+        assert resolved.query == {
+            "properties": {"common": {"in": "query", "name": "common", "schema": {"type": "integer"}}},
+            "additionalProperties": False,
+            "type": "object",
+            "required": ["common"],
+        }

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -73,7 +73,7 @@ def app():
         return web.Response()
 
     app = web.Application()
-    app.add_routes([web.get("/swagger.yaml", schema), web.get("/v1/users", users)])
+    app.add_routes([web.get("/schema.yaml", schema), web.get("/v1/users", users)])
     app["saved_requests"] = saved_requests
     return app
 

--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -8,7 +8,7 @@ from schemathesis import Case
 
 @pytest.fixture()
 def schema(flask_app):
-    return schemathesis.from_wsgi("/swagger.yaml", flask_app)
+    return schemathesis.from_wsgi("/schema.yaml", flask_app)
 
 
 @pytest.mark.hypothesis_nested
@@ -135,7 +135,7 @@ def test_app_with_parametrize(testdir):
     from test.apps._flask.app import app
     from hypothesis import settings
 
-    schema = schemathesis.from_wsgi("/swagger.yaml", app)
+    schema = schemathesis.from_wsgi("/schema.yaml", app)
 
     called = False
 


### PR DESCRIPTION
Resolves #392 

Some of the currently failing tests point to actual errors and probably I'll resolve them separately (e.g. sending multipart on OAS3)

TODO:
- [x] Add a CLI param to the test app (the one invoked with `./test_server.sh`
- [x] Reduce code duplication in `utils.py` where schemas are created