### PR TITLE
fix: Content type conformance check for cases when Open API 3.0 schemas contain "default" response definitions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ Added
 
 - Support for property-level examples. `#467`_
 
+Fixed
+~~~~~
+
+- Content type conformance check for cases when Open API 3.0 schemas contain "default" response definitions. `#641`_
+
 `2.0.0`_ - 2020-07-01
 ---------------------
 
@@ -1209,6 +1214,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#641: https://github.com/kiwicom/schemathesis/issues/641
 .. _#631: https://github.com/kiwicom/schemathesis/issues/631
 .. _#629: https://github.com/kiwicom/schemathesis/issues/629
 .. _#621: https://github.com/kiwicom/schemathesis/issues/621

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -361,8 +361,14 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
         except KeyError:
             # Possible to get if `validate_schema=False` is passed during schema creation
             raise InvalidSchema("Schema parsing failed. Please check your schema.")
-        definitions = responses.get(str(response.status_code), {}).get("content", {})
-        return list(definitions.keys())
+        status_code = str(response.status_code)
+        if status_code in responses:
+            definitions = responses[status_code]
+        elif "default" in responses:
+            definitions = responses["default"]
+        else:
+            return []
+        return list(definitions.get("content", {}).keys())
 
     def get_hypothesis_conversion(self, definitions: List[Dict[str, Any]]) -> Optional[Callable]:
         return serialization.serialize_openapi3_parameters(definitions)


### PR DESCRIPTION
Fixes #641 