### PR TITLE
fix: Handling of multipart requests for Open API 3.0 schemas

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Fixed
 ~~~~~
 
 - Content type conformance check for cases when Open API 3.0 schemas contain "default" response definitions. `#641`_
+- Handling of multipart requests for Open API 3.0 schemas. `#640`_
 - Sending non-file form fields in multipart requests. `#647`_
 
 Removed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Fixed
 ~~~~~
 
 - Content type conformance check for cases when Open API 3.0 schemas contain "default" response definitions. `#641`_
+- Sending non-file form fields in multipart requests. `#647`_
 
 Removed
 ~~~~~~~
@@ -1220,7 +1221,9 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#647: https://github.com/kiwicom/schemathesis/issues/647
 .. _#641: https://github.com/kiwicom/schemathesis/issues/641
+.. _#640: https://github.com/kiwicom/schemathesis/issues/640
 .. _#631: https://github.com/kiwicom/schemathesis/issues/631
 .. _#629: https://github.com/kiwicom/schemathesis/issues/629
 .. _#621: https://github.com/kiwicom/schemathesis/issues/621

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -121,39 +121,13 @@ def is_valid_query(query: Dict[str, Any]) -> bool:
     return True
 
 
-def _is_valid_list(value: List) -> bool:
-    # Based on `https://github.com/psf/requests/blob/1b417634721ec377abb7f17bc1f215e07202c2f7/requests/models.py#L146`
-    if len(value) == 2:
-        file_name, file_pointer = value
-        return isinstance(file_name, str) and isinstance(file_pointer, (str, bytes))
-    if len(value) == 3:
-        file_name, file_pointer, content_type = value
-        return (
-            isinstance(file_name, str)
-            and isinstance(file_pointer, (str, bytes))
-            and isinstance(content_type, (str, bytes))
-        )
-    if len(value) == 4:
-        file_name, file_pointer, content_type, headers = value
-        return (
-            isinstance(file_name, str)
-            and isinstance(file_pointer, (str, bytes))
-            and isinstance(content_type, (str, bytes))
-            and isinstance(headers, dict)
-        )
-    return False
-
-
 def is_valid_form_data(form_data: Dict[str, Any]) -> bool:
     """Multipart encoder accepts a very limited input set."""
     for value in form_data.values():
-        # `requests` supports the following tuples:
-        #   - filename, payload
-        #   - filename, payload, content type
-        #   - filename, payload, content type, headers
-        if isinstance(value, list) and not _is_valid_list(value):
-            return False
-        if not isinstance(value, (str, bytes, int)):
+        if isinstance(value, list):
+            # A list of files is generated
+            return all(isinstance(item, bytes) for item in value)
+        if not isinstance(value, (str, bytes, int, bool)):
             return False
     return True
 

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -121,6 +121,43 @@ def is_valid_query(query: Dict[str, Any]) -> bool:
     return True
 
 
+def _is_valid_list(value: List) -> bool:
+    # Based on `https://github.com/psf/requests/blob/1b417634721ec377abb7f17bc1f215e07202c2f7/requests/models.py#L146`
+    if len(value) == 2:
+        file_name, file_pointer = value
+        return isinstance(file_name, str) and isinstance(file_pointer, (str, bytes))
+    if len(value) == 3:
+        file_name, file_pointer, content_type = value
+        return (
+            isinstance(file_name, str)
+            and isinstance(file_pointer, (str, bytes))
+            and isinstance(content_type, (str, bytes))
+        )
+    if len(value) == 4:
+        file_name, file_pointer, content_type, headers = value
+        return (
+            isinstance(file_name, str)
+            and isinstance(file_pointer, (str, bytes))
+            and isinstance(content_type, (str, bytes))
+            and isinstance(headers, dict)
+        )
+    return False
+
+
+def is_valid_form_data(form_data: Dict[str, Any]) -> bool:
+    """Multipart encoder accepts a very limited input set."""
+    for value in form_data.values():
+        # `requests` supports the following tuples:
+        #   - filename, payload
+        #   - filename, payload, content type
+        #   - filename, payload, content type, headers
+        if isinstance(value, list) and not _is_valid_list(value):
+            return False
+        if not isinstance(value, (str, bytes, int)):
+            return False
+    return True
+
+
 def get_case_strategy(endpoint: Endpoint, hooks: Optional[HookDispatcher] = None) -> st.SearchStrategy:
     """Create a strategy for a complete test case.
 
@@ -149,6 +186,8 @@ def prepare_strategy(parameter: str, value: Dict[str, Any], map_func: Optional[C
         strategy = strategy.filter(is_valid_header)  # type: ignore
     elif parameter == "query":
         strategy = strategy.filter(is_valid_query)  # type: ignore
+    elif parameter == "form_data":
+        strategy = strategy.filter(is_valid_form_data)  # type: ignore
     return strategy
 
 

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -118,7 +118,8 @@ class Case:
         # Form data and body are mutually exclusive
         extra: Dict[str, Optional[Body]]
         if self.form_data:
-            extra = {"files": self.form_data}
+            files, data = self.endpoint.prepare_multipart(self.form_data)
+            extra = {"files": files, "data": data}
         elif is_multipart(self.body):
             extra = {"data": self.body}
         else:
@@ -333,6 +334,13 @@ class Endpoint:
         if definitions:
             return self.schema.get_hypothesis_conversion(definitions)
         return None
+
+    def prepare_multipart(
+        self, form_data: Optional[FormData]
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        if not form_data:
+            return None, None
+        return self.schema.prepare_multipart(form_data, self)
 
     def partial_deepcopy(self) -> "Endpoint":
         return self.__class__(

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -165,7 +165,8 @@ class Case:
         if self.form_data:
             extra = {"data": self.form_data}
             final_headers = final_headers or {}
-            final_headers.setdefault("Content-Type", "multipart/form-data")
+            if "multipart/form-data" in self.endpoint.get_request_payload_content_types():
+                final_headers.setdefault("Content-Type", "multipart/form-data")
         elif is_multipart(self.body):
             extra = {"data": self.body}
         else:
@@ -335,12 +336,13 @@ class Endpoint:
             return self.schema.get_hypothesis_conversion(definitions)
         return None
 
-    def prepare_multipart(
-        self, form_data: Optional[FormData]
-    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    def prepare_multipart(self, form_data: Optional[FormData]) -> Tuple[Optional[List], Optional[Dict[str, Any]]]:
         if not form_data:
             return None, None
         return self.schema.prepare_multipart(form_data, self)
+
+    def get_request_payload_content_types(self) -> List[str]:
+        return self.schema.get_request_payload_content_types(self)
 
     def partial_deepcopy(self) -> "Endpoint":
         return self.__class__(

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -196,9 +196,12 @@ class BaseSchema(Mapping):
 
     def prepare_multipart(
         self, form_data: FormData, endpoint: Endpoint
-    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    ) -> Tuple[Optional[List], Optional[Dict[str, Any]]]:
         """Split content of `form_data` into files & data.
 
         Forms may contain file fields, that we should send via `files` argument in `requests`.
         """
+        raise NotImplementedError
+
+    def get_request_payload_content_types(self, endpoint: Endpoint) -> List[str]:
         raise NotImplementedError

--- a/src/schemathesis/schemas.py
+++ b/src/schemathesis/schemas.py
@@ -21,7 +21,7 @@ from .exceptions import InvalidSchema
 from .hooks import HookContext, HookDispatcher, HookScope, dispatch
 from .models import Case, Endpoint
 from .stateful import StatefulTest
-from .types import Filter, GenericTest, NotSet
+from .types import Filter, FormData, GenericTest, NotSet
 from .utils import NOT_SET, GenericResponse
 
 
@@ -193,3 +193,12 @@ class BaseSchema(Mapping):
         local_dispatcher = self.get_local_hook_dispatcher()
         if local_dispatcher is not None:
             local_dispatcher.dispatch(name, context, *args, **kwargs)
+
+    def prepare_multipart(
+        self, form_data: FormData, endpoint: Endpoint
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        """Split content of `form_data` into files & data.
+
+        Forms may contain file fields, that we should send via `files` argument in `requests`.
+        """
+        raise NotImplementedError

--- a/test/apps/_flask/__init__.py
+++ b/test/apps/_flask/__init__.py
@@ -104,6 +104,12 @@ def create_openapi_app(
     def upload_file():
         return jsonify({"size": request.content_length})
 
+    @app.route("/api/form", methods=["POST"])
+    def form():
+        if request.headers["Content-Type"] != "application/x-www-form-urlencoded":
+            raise InternalServerError("Not an urlencoded request!")
+        return jsonify({"size": request.content_length})
+
     @app.route("/api/teapot", methods=["POST"])
     def teapot():
         return jsonify({"success": True}), 418

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -156,7 +156,10 @@ def _make_openapi_2_schema(endpoints: Tuple[str, ...]) -> Dict:
             }
         elif endpoint == "upload_file":
             schema = {
-                "parameters": [{"name": "data", "in": "formData", "required": True, "type": "file"}],
+                "parameters": [
+                    {"name": "note", "in": "formData", "required": True, "type": "string"},
+                    {"name": "data", "in": "formData", "required": True, "type": "file"},
+                ],
                 "responses": {"200": {"description": "OK"}},
             }
         elif endpoint == "custom_format":
@@ -354,8 +357,11 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
                         "multipart/form-data": {
                             "schema": {
                                 "type": "object",
-                                "properties": {"file": {"type": "string", "format": "binary"}},
-                                "required": ["file"],
+                                "properties": {
+                                    "data": {"type": "string", "format": "binary"},
+                                    "note": {"type": "string"},
+                                },
+                                "required": ["data", "note"],
                             }
                         }
                     },

--- a/test/apps/utils.py
+++ b/test/apps/utils.py
@@ -18,6 +18,7 @@ class Endpoint(Enum):
     recursive = ("GET", "/api/recursive")
     multipart = ("POST", "/api/multipart")
     upload_file = ("POST", "/api/upload_file")
+    form = ("POST", "/api/form")
     teapot = ("POST", "/api/teapot")
     text = ("GET", "/api/text")
     malformed_json = ("GET", "/api/malformed_json")
@@ -162,6 +163,15 @@ def _make_openapi_2_schema(endpoints: Tuple[str, ...]) -> Dict:
                 ],
                 "responses": {"200": {"description": "OK"}},
             }
+        elif endpoint == "form":
+            schema = {
+                "parameters": [
+                    {"name": "first_name", "in": "formData", "required": True, "type": "string"},
+                    {"name": "last_name", "in": "formData", "required": True, "type": "string"},
+                ],
+                "consumes": ["application/x-www-form-urlencoded"],
+                "responses": {"200": {"description": "OK"}},
+            }
         elif endpoint == "custom_format":
             schema = {
                 "parameters": [{"name": "id", "in": "query", "required": True, "type": "string", "format": "digits"}],
@@ -173,6 +183,7 @@ def _make_openapi_2_schema(endpoints: Tuple[str, ...]) -> Dict:
                     {"in": "formData", "name": "key", "required": True, "type": "string"},
                     {"in": "formData", "name": "value", "required": True, "type": "integer"},
                 ],
+                "consumes": ["multipart/form-data"],
                 "responses": {"200": {"description": "OK"}},
             }
         elif endpoint == "teapot":
@@ -362,6 +373,23 @@ def _make_openapi_3_schema(endpoints: Tuple[str, ...]) -> Dict:
                                     "note": {"type": "string"},
                                 },
                                 "required": ["data", "note"],
+                            }
+                        }
+                    },
+                },
+                "responses": {"200": {"description": "OK"}},
+            }
+        elif endpoint == "form":
+            schema = {
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "additionalProperties": False,
+                                "type": "object",
+                                "properties": {"first_name": {"type": "string"}, "last_name": {"type": "string"},},
+                                "required": ["first_name", "last_name"],
                             }
                         }
                     },

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -250,9 +250,7 @@ def test_hypothesis_deadline(args):
 
 
 @pytest.mark.endpoints("multipart")
-def test_form_data(openapi_version, args):
-    if openapi_version.is_openapi_3:
-        pytest.xfail(reason="Multipart handling is broken for Open API 3.0. Ref: #640")
+def test_form_data(args):
     app, kwargs = args
 
     def is_ok(response, case):


### PR DESCRIPTION
Fixes #640
Fixes #647 

TODO:
- [x] Check tests that were parametrized but always use only one spec version
- [x] Tests for urlencoded endpoints
- [x] Verify that data, that `requests` can't send as files won't be generated
- [x] Test & implement similar changes for WSGI / ASGI