### PR TITLE
fix: Possible `UnicodeEncodeError` during generation of `Authorization` header values for endpoints with `basic` security scheme

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Possible ``UnicodeEncodeError`` during generation of ``Authorization`` header values for endpoints with ``basic`` security scheme. `#656`_
+
 `2.2.0`_ - 2020-07-14
 ---------------------
 
@@ -1241,6 +1246,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#656: https://github.com/kiwicom/schemathesis/issues/656
 .. _#651: https://github.com/kiwicom/schemathesis/issues/651
 .. _#647: https://github.com/kiwicom/schemathesis/issues/647
 .. _#641: https://github.com/kiwicom/schemathesis/issues/641

--- a/src/schemathesis/specs/openapi/_hypothesis.py
+++ b/src/schemathesis/specs/openapi/_hypothesis.py
@@ -24,5 +24,7 @@ def init_default_strategies() -> None:
     def make_basic_auth_str(item: Tuple[str, str]) -> str:
         return _basic_auth_str(*item)
 
-    register_string_format("_basic_auth", st.tuples(st.text(), st.text()).map(make_basic_auth_str))  # type: ignore
+    latin1_text = st.text(alphabet=st.characters(min_codepoint=0, max_codepoint=255))
+
+    register_string_format("_basic_auth", st.tuples(latin1_text, latin1_text).map(make_basic_auth_str))  # type: ignore
     register_string_format("_bearer_auth", st.text().map("Bearer {}".format))

--- a/test/test_parameters.py
+++ b/test/test_parameters.py
@@ -246,7 +246,7 @@ def test_security_definitions_basic_auth(testdir, basic_auth_schema):
 import base64
 
 @schema.parametrize()
-@settings(max_examples=1, deadline=None)
+@settings(max_examples=10, deadline=None)
 def test_(case):
     assert "Authorization" in case.headers
     auth = case.headers["Authorization"]


### PR DESCRIPTION
Fixes #656 