### PR TITLE
fix: `ValueError` during sending a request with test payload if the endpoint defines a parameter with type: array` and `in: formData`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- ``ValueError`` during sending a request with test payload if the endpoint defines a parameter with ``type: array`` and ``in: formData``. `#661`_
+
 `2.2.1`_ - 2020-07-22
 ---------------------
 
@@ -1250,6 +1255,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#661: https://github.com/kiwicom/schemathesis/issues/661
 .. _#656: https://github.com/kiwicom/schemathesis/issues/656
 .. _#651: https://github.com/kiwicom/schemathesis/issues/651
 .. _#647: https://github.com/kiwicom/schemathesis/issues/647

--- a/src/schemathesis/_hypothesis.py
+++ b/src/schemathesis/_hypothesis.py
@@ -124,7 +124,7 @@ def is_valid_form_data(form_data: Dict[str, Any]) -> bool:
     for value in form_data.values():
         if isinstance(value, list):
             # A list of files is generated
-            return all(isinstance(item, bytes) for item in value)
+            return bool(value) and all(isinstance(item, bytes) for item in value)
         if not isinstance(value, (str, bytes, int, bool)):
             return False
     return True

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -187,32 +187,37 @@ def test_valid_headers(openapi2_base_url, swagger_20, definition):
     inner()
 
 
+def make_swagger(*parameters):
+    return {
+        "swagger": "2.0",
+        "info": {"title": "Sample API", "description": "API description in Markdown.", "version": "1.0.0"},
+        "host": "api.example.com",
+        "basePath": "/v1",
+        "schemes": ["https"],
+        "paths": {
+            "/form": {
+                "post": {
+                    "parameters": list(parameters),
+                    "summary": "Returns a list of users.",
+                    "description": "Optional extended description in Markdown.",
+                    "consumes": ["multipart/form-data"],
+                    "produces": ["application/json"],
+                    "responses": {"200": {"description": "OK"}},
+                }
+            }
+        },
+    }
+
+
 @pytest.mark.parametrize(
     "raw_schema",
     (
-        {
-            "swagger": "2.0",
-            "info": {"title": "Sample API", "description": "API description in Markdown.", "version": "1.0.0"},
-            "host": "api.example.com",
-            "basePath": "/v1",
-            "schemes": ["https"],
-            "paths": {
-                "/form": {
-                    "post": {
-                        "parameters": [
-                            {"name": "a", "in": "formData", "required": True, "type": "number"},
-                            {"name": "b", "in": "formData", "required": True, "type": "boolean"},
-                            {"name": "c", "in": "formData", "required": True, "type": "array"},
-                        ],
-                        "summary": "Returns a list of users.",
-                        "description": "Optional extended description in Markdown.",
-                        "consumes": ["multipart/form-data"],
-                        "produces": ["application/json"],
-                        "responses": {"200": {"description": "OK"}},
-                    }
-                }
-            },
-        },
+        make_swagger(
+            {"name": "a", "in": "formData", "required": True, "type": "number"},
+            {"name": "b", "in": "formData", "required": True, "type": "boolean"},
+            {"name": "c", "in": "formData", "required": True, "type": "array"},
+        ),
+        make_swagger({"name": "c", "in": "formData", "required": True, "type": "array"},),
         {
             "openapi": "3.0.2",
             "info": {"title": "Test", "description": "Test", "version": "0.1.0"},


### PR DESCRIPTION
Fixes #661 