### PR TITLE
fix: `KeyError` during processing a schema with nullable parameters and `in: body`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Fixed
 ~~~~~
 
 - ``ValueError`` during sending a request with test payload if the endpoint defines a parameter with ``type: array`` and ``in: formData``. `#661`_
+- ``KeyError`` during processing a schema with nullable parameters and ``in: body``. `#660`_
 
 `2.2.1`_ - 2020-07-22
 ---------------------
@@ -1256,6 +1257,7 @@ Fixed
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
 .. _#661: https://github.com/kiwicom/schemathesis/issues/661
+.. _#660: https://github.com/kiwicom/schemathesis/issues/660
 .. _#656: https://github.com/kiwicom/schemathesis/issues/656
 .. _#651: https://github.com/kiwicom/schemathesis/issues/651
 .. _#647: https://github.com/kiwicom/schemathesis/issues/647

--- a/src/schemathesis/specs/openapi/converter.py
+++ b/src/schemathesis/specs/openapi/converter.py
@@ -13,7 +13,10 @@ def to_json_schema(schema: Dict[str, Any], nullable_name: str) -> Dict[str, Any]
     schema = deepcopy(schema)
     if schema.get(nullable_name) is True:
         del schema[nullable_name]
-        if schema.get("in"):
+        in_ = schema.get("in")
+        if in_ == "body":
+            schema["schema"] = {"anyOf": [schema["schema"], {"type": "null"}]}
+        elif in_:
             initial_type = {"type": schema["type"]}
             if schema.get("enum"):
                 initial_type["enum"] = schema.pop("enum")

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -17,6 +17,10 @@ from schemathesis.utils import traverse_schema
             {"x-nullable": True, "type": "integer", "enum": [1, 2]},
             {"anyOf": [{"type": "integer", "enum": [1, 2]}, {"type": "null"}]},
         ),
+        (
+            {"in": "body", "name": "foo", "schema": {"type": "string"}, "x-nullable": True},
+            {"in": "body", "name": "foo", "schema": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+        ),
     ),
 )
 def test_to_jsonschema(schema, expected):


### PR DESCRIPTION
Fixes #660