### PR TITLE
feat: Possibility to generate values for `in: formData` parameters that are non-bytes or contain non-bytes (e.g. inside an array)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Possibility to generate values for ``in: formData`` parameters that are non-bytes or contain non-bytes (e.g. inside an array). `#665`_
+
 Fixed
 ~~~~~
 
@@ -1256,6 +1261,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#665: https://github.com/kiwicom/schemathesis/issues/665
 .. _#661: https://github.com/kiwicom/schemathesis/issues/661
 .. _#660: https://github.com/kiwicom/schemathesis/issues/660
 .. _#656: https://github.com/kiwicom/schemathesis/issues/656

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -279,7 +279,11 @@ class SwaggerV20(BaseOpenAPISchema):
             name = parameter["name"]
             if name in form_data:
                 if parameter["in"] == "formData" and (is_file(parameter) or is_multipart):
-                    files.append((name, form_data[name]))
+                    if isinstance(form_data[name], list):
+                        for item in form_data[name]:
+                            files.append((name, (None, item)))
+                    else:
+                        files.append((name, form_data[name]))
                 else:
                     data[name] = form_data[name]
         # `None` is the default value for `files` and `data` arguments in `requests.request`

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 
-import hypothesis.errors
 import pytest
 from hypothesis import HealthCheck, given, settings, strategies
 
@@ -217,7 +216,7 @@ def make_swagger(*parameters):
             {"name": "b", "in": "formData", "required": True, "type": "boolean"},
             {"name": "c", "in": "formData", "required": True, "type": "array"},
         ),
-        make_swagger({"name": "c", "in": "formData", "required": True, "type": "array"},),
+        make_swagger({"name": "c", "in": "formData", "required": True, "type": "array"}),
         {
             "openapi": "3.0.2",
             "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
@@ -261,9 +260,8 @@ def test_valid_form_data(request, raw_schema):
     def inner(case):
         case.call()
 
-    # Then such values should not be generated at all and there should be no error on the `requests` level
-    with pytest.raises(hypothesis.errors.FailedHealthCheck):
-        inner()
+    # Then these values should be casted to bytes and handled successfully
+    inner()
 
 
 @pytest.mark.parametrize("value, expected", (({"key": "1"}, True), ({"key": 1}, True), ({"key": "\udcff"}, False)))


### PR DESCRIPTION
Resolves #665