### PR TITLE
fix: `StopIteration` during `requestBody` processing if it has empty "content" value

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Fixed
 
 - ``ValueError`` during sending a request with test payload if the endpoint defines a parameter with ``type: array`` and ``in: formData``. `#661`_
 - ``KeyError`` during processing a schema with nullable parameters and ``in: body``. `#660`_
+- ``StopIteration`` during ``requestBody`` processing if it has empty "content" value. `#673`_
 
 `2.2.1`_ - 2020-07-22
 ---------------------
@@ -1261,6 +1262,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#673: https://github.com/kiwicom/schemathesis/issues/673
 .. _#665: https://github.com/kiwicom/schemathesis/issues/665
 .. _#661: https://github.com/kiwicom/schemathesis/issues/661
 .. _#660: https://github.com/kiwicom/schemathesis/issues/660

--- a/src/schemathesis/specs/openapi/schemas.py
+++ b/src/schemathesis/specs/openapi/schemas.py
@@ -358,7 +358,11 @@ class OpenApi30(SwaggerV20):  # pylint: disable=too-many-ancestors
     def process_body(self, endpoint: Endpoint, parameter: Dict[str, Any]) -> None:
         # Take the first media type object
         options = iter(parameter["content"].items())
-        content_type, parameter = next(options)
+        try:
+            content_type, parameter = next(options)
+        except StopIteration:
+            # empty "content" value
+            return None
         # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#media-type-object
         # > Furthermore, if referencing a schema which contains an example,
         # > the example value SHALL override the example provided by the schema

--- a/test/test_parametrization.py
+++ b/test/test_parametrization.py
@@ -1,5 +1,7 @@
 import pytest
 
+import schemathesis
+
 from .utils import integer
 
 
@@ -607,6 +609,19 @@ def test_(request, case):
     result.assert_outcomes(passed=2)
     result.stdout.re_match_lines([r".*\[GET:/api/failure\]", r".*\[GET:/api/success\]"])
     assert len(openapi_3_app["incoming_requests"]) == 2
+
+
+def test_empty_content():
+    # When the "content" value is empty in "requestBody"
+    raw_schema = {
+        "openapi": "3.0.2",
+        "info": {"title": "Test", "description": "Test", "version": "0.1.0"},
+        "paths": {"/body": {"post": {"requestBody": {"content": {}}, "responses": {"200": {"description": "OK"}}}}},
+    }
+    schema = schemathesis.from_dict(raw_schema)
+    # Then the body processing should be no-op
+    endpoint = schema.endpoints["/body"]["POST"]
+    assert endpoint.body is None
 
 
 def test_exceptions_on_collect(testdir):


### PR DESCRIPTION
Fixes #673