### PR TITLE
chore: Error message for cases when a path parameter is in template but is not defined in the parameters list or missing `required: true` in its definition

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ Added
 
 - Possibility to generate values for ``in: formData`` parameters that are non-bytes or contain non-bytes (e.g. inside an array). `#665`_
 
+Changed
+~~~~~~~
+
+- Error message for cases when a path parameter is in template but is not defined in the parameters list or missing ``required: true`` in its definition. `#667`_
+
 Fixed
 ~~~~~
 
@@ -1270,6 +1275,7 @@ Fixed
 .. _#673: https://github.com/kiwicom/schemathesis/issues/673
 .. _#672: https://github.com/kiwicom/schemathesis/issues/672
 .. _#668: https://github.com/kiwicom/schemathesis/issues/668
+.. _#667: https://github.com/kiwicom/schemathesis/issues/667
 .. _#665: https://github.com/kiwicom/schemathesis/issues/665
 .. _#661: https://github.com/kiwicom/schemathesis/issues/661
 .. _#660: https://github.com/kiwicom/schemathesis/issues/660

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -64,8 +64,10 @@ class Case:
         # pylint: disable=not-a-mapping
         try:
             return self.path.format(**self.path_parameters or {})
-        except KeyError:
-            raise InvalidSchema("Missing required property `required: true`")
+        except KeyError as variable:
+            raise InvalidSchema(
+                f"Missing path parameter {variable}. It either not defined or has no `required: true` in its definition"
+            )
 
     def get_full_base_url(self) -> Optional[str]:
         """Create a full base url, adding "localhost" for WSGI apps."""

--- a/test/runner/test_runner.py
+++ b/test/runner/test_runner.py
@@ -482,7 +482,10 @@ def test_invalid_path_parameter(args):
     app, kwargs = args
     init, *others, finished = prepare(validate_schema=False, **kwargs)
     assert finished.has_errors
-    assert "schemathesis.exceptions.InvalidSchema: Missing required property" in others[1].result.errors[0].exception
+    assert (
+        "schemathesis.exceptions.InvalidSchema: Missing path parameter 'id'. "
+        "It either not defined or has no `required: true` in its definition" in others[1].result.errors[0].exception
+    )
 
 
 def test_get_requests_auth():


### PR DESCRIPTION
Resolves #667