### PR TITLE
feat: run checks conditionally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,21 @@ After registration, your checks will be available in Schemathesis CLI and you ca
 
     schemathesis --pre-run module.with.checks run -c new_check https://example.com/api/swagger.json
 
+Additionally, checks may return ``True`` to skip the check under certain conditions. For example, you may only want to run checks when the
+response code is ``200``.
+
+.. code:: python
+
+    import schemathesis
+
+    @schemathesis.register_check
+    def conditional_check(response, case):
+        if response.status_code == 200:
+            # some awesome assertions!
+        else:
+            # check not relevant to this response, skip test
+            return True
+
 In-code
 ~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+- Run checks conditionally.
+
 `2.3.1`_ - 2020-07-28
 ---------------------
 

--- a/src/schemathesis/checks.py
+++ b/src/schemathesis/checks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Tuple
+from typing import TYPE_CHECKING, Callable, Optional, Tuple
 
 from .exceptions import get_status_code_error
 from .specs.openapi.checks import content_type_conformance, response_schema_conformance, status_code_conformance
@@ -8,13 +8,14 @@ if TYPE_CHECKING:
     from .models import Case
 
 
-def not_a_server_error(response: GenericResponse, case: "Case") -> None:
+def not_a_server_error(response: GenericResponse, case: "Case") -> Optional[bool]:  # pylint: disable=useless-return
     """A check to verify that the response is not a server-side error."""
     if response.status_code >= 500:
         exc_class = get_status_code_error(response.status_code)
         raise exc_class(f"Received a response with 5xx status code: {response.status_code}")
+    return None
 
 
 DEFAULT_CHECKS = (not_a_server_error,)
 OPTIONAL_CHECKS = (status_code_conformance, content_type_conformance, response_schema_conformance)
-ALL_CHECKS: Tuple[Callable[[GenericResponse, "Case"], None], ...] = DEFAULT_CHECKS + OPTIONAL_CHECKS
+ALL_CHECKS: Tuple[Callable[[GenericResponse, "Case"], Optional[bool]], ...] = DEFAULT_CHECKS + OPTIONAL_CHECKS

--- a/src/schemathesis/models.py
+++ b/src/schemathesis/models.py
@@ -213,7 +213,7 @@ class Case:
     def validate_response(
         self,
         response: Union[requests.Response, WSGIResponse],
-        checks: Tuple[Callable[[Union[requests.Response, WSGIResponse], "Case"], None], ...] = ALL_CHECKS,
+        checks: Tuple[Callable[[Union[requests.Response, WSGIResponse], "Case"], Optional[bool]], ...] = ALL_CHECKS,
     ) -> None:
         errors = []
         for check in checks:
@@ -594,4 +594,4 @@ class TestResultSet:
         self.results.append(item)
 
 
-CheckFunction = Callable[[GenericResponse, Case], None]  # pragma: no mutate
+CheckFunction = Callable[[GenericResponse, Case], Optional[bool]]  # pragma: no mutate

--- a/src/schemathesis/runner/impl/core.py
+++ b/src/schemathesis/runner/impl/core.py
@@ -219,8 +219,9 @@ def run_checks(case: Case, checks: Iterable[CheckFunction], result: TestResult, 
     for check in checks:
         check_name = check.__name__
         try:
-            check(response, case)
-            result.add_success(check_name, case)
+            skip_check = check(response, case)
+            if not skip_check:
+                result.add_success(check_name, case)
         except AssertionError as exc:
             errors.append(exc)
             result.add_failure(check_name, case, str(exc))


### PR DESCRIPTION
@Stranger6667  We have custom checks that are only relevant in certain circumstances. For example, we have a check that only runs an assertion when the response status code is `406`. Currently, all checks run against all responses. This is OK and still correct, but the final results may be misleading. Consider the case where we send 100 requests during testing, and we only have one response with a status code of `406`. Lets assume the above-mentioned check (that only runs when the response status code is `406`) fails for the `406` response. Before, the output would say:

    406-check    99 / 100

but it would be more accurate to say:

    406-check    0 / 1

Note: I updated the return type of the checks to `Optional[bool]`. `MyPy`, however, failed unless the checks explicitly returned `None` even when the return type was marked `Optional`. Hence, I explicitly returned `None` for each of the checks. 