### PR TITLE
fix: `KeyError` during the `content_type_conformance` check if the response has no `Content-Type` header

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- ``KeyError`` during the ``content_type_conformance`` check if the response has no ``Content-Type`` header. `#692`_
+
 `2.3.2`_ - 2020-08-04
 ---------------------
 
@@ -1294,6 +1299,7 @@ Fixed
 .. _0.3.0: https://github.com/kiwicom/schemathesis/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/schemathesis/compare/v0.1.0...v0.2.0
 
+.. _#692: https://github.com/kiwicom/schemathesis/issues/692
 .. _#684: https://github.com/kiwicom/schemathesis/issues/684
 .. _#675: https://github.com/kiwicom/schemathesis/issues/675
 .. _#673: https://github.com/kiwicom/schemathesis/issues/673

--- a/src/schemathesis/specs/openapi/checks.py
+++ b/src/schemathesis/specs/openapi/checks.py
@@ -46,7 +46,9 @@ def content_type_conformance(response: GenericResponse, case: "Case") -> Optiona
     content_types = case.endpoint.schema.get_content_types(case.endpoint, response)
     if not content_types:
         return None
-    content_type = response.headers["Content-Type"]
+    content_type = response.headers.get("Content-Type")
+    if not content_type:
+        return None
     for option in content_types:
         if are_content_types_equal(option, content_type):
             return None


### PR DESCRIPTION
Fixes #692